### PR TITLE
Fix thermo-nuclear code quality review findings

### DIFF
--- a/src/wilma/__main__.py
+++ b/src/wilma/__main__.py
@@ -107,14 +107,11 @@ Examples:
 
         # Override config with CLI arguments if provided
         if args.checks:
-            check_list = [c.strip() for c in args.checks.split(',')]
-            config.config['checks']['enabled'] = check_list
-            config._validate_config()
+            config.set_enabled_checks([c.strip() for c in args.checks.split(',')])
             print(f"[INFO] Running selective checks: {', '.join(config.enabled_checks)}")
 
         if args.min_risk:
-            config.config['output']['min_risk_level'] = args.min_risk
-            config._validate_config()
+            config.set_min_risk_level(args.min_risk)
             print(f"[INFO] Filtering findings: minimum risk level = {args.min_risk}")
 
         # Handle --show-config flag
@@ -142,7 +139,6 @@ Examples:
                 region=args.region,
                 mode=mode,
                 config=config,
-                presentation_mode=presentation_mode,
             )
 
             # Run all checks

--- a/src/wilma/assessment.py
+++ b/src/wilma/assessment.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import Any
 
+import wilma
 from wilma.enums import RiskLevel
 
 SCHEMA_VERSION = "2.0"
@@ -196,6 +197,20 @@ SEVERITY_ORDER = {
     "INFO": 1,
 }
 
+# Legacy findings carry a closed set of category labels; map them directly to
+# indicators so classification is deterministic. Keyword inference below is
+# only a fallback for rich findings without a category.
+CATEGORY_INDICATORS = {
+    "Access Control": "identity_access_agency",
+    "Audit & Compliance": "monitoring_logging_detection",
+    "Cost Security": "resilience_consumption_controls",
+    "Data Privacy": "data_protection_privacy",
+    "GenAI Security": "ai_safety_guardrails",
+    "Model Security": "rag_model_integrity",
+    "Network Security": "network_runtime_isolation",
+    "Resource Management": "governance_inventory",
+}
+
 INDICATOR_KEYWORDS = [
     (
         "resilience_consumption_controls",
@@ -255,15 +270,11 @@ INDICATOR_KEYWORDS = [
 
 
 def risk_level_label(value: Any) -> str:
-    """Return a stable severity label from RiskLevel enums or strings."""
+    """Return a stable severity label from RiskLevel enums or severity strings."""
     if isinstance(value, RiskLevel):
         return value.label
-    if value is None:
-        return "INFO"
-    if isinstance(value, str):
-        label = value.split(".")[-1].upper()
-        if label in SEVERITY_PENALTIES:
-            return label
+    if isinstance(value, str) and value.upper() in SEVERITY_PENALTIES:
+        return value.upper()
     return "INFO"
 
 
@@ -305,6 +316,10 @@ def infer_indicator_id(finding: dict[str, Any]) -> str:
         normalized = str(explicit_indicator).lower().replace(" ", "_").replace("&", "and")
         if normalized in INDICATOR_BY_ID:
             return normalized
+
+    category_indicator = CATEGORY_INDICATORS.get(finding.get("category"))
+    if category_indicator:
+        return category_indicator
 
     text = _join_finding_text(finding)
     for indicator_id, keywords in INDICATOR_KEYWORDS:
@@ -418,24 +433,26 @@ def _highest_severity(findings: Iterable[dict[str, Any]]):
 
 
 class AssessmentBuilder:
-    """Build the versioned Wilma assessment from a checker instance."""
+    """
+    Build the versioned Wilma assessment from a checker instance.
+
+    The checker contract: findings, filtered_findings(), good_practices,
+    available_models, assessed_indicators, visibility_gaps, account_id,
+    region, and mode.
+    """
 
     def __init__(self, checker: Any):
         self.checker = checker
 
     def build(self) -> dict[str, Any]:
-        filtered_findings = getattr(self.checker, "filtered_findings", None)
-        if callable(filtered_findings):
-            raw_findings = list(filtered_findings())
-        else:
-            raw_findings = list(getattr(self.checker, "findings", []))
+        raw_findings = list(self.checker.filtered_findings())
         normalized_findings = [normalize_finding(finding, index) for index, finding in enumerate(raw_findings, 1)]
         counts = self._severity_counts(normalized_findings)
         score = self._posture_score(normalized_findings)
-        assessed_indicators = set(getattr(self.checker, "assessed_indicators", set()))
+        assessed_indicators = set(self.checker.assessed_indicators)
         assessed_indicators.update(finding["indicator_id"] for finding in normalized_findings)
         indicator_scores = self._indicator_scores(normalized_findings, assessed_indicators)
-        visibility_gaps = list(getattr(self.checker, "visibility_gaps", []))
+        visibility_gaps = list(self.checker.visibility_gaps)
         confidence = self._assessment_confidence(assessed_indicators, visibility_gaps)
 
         summary = {
@@ -445,7 +462,7 @@ class AssessmentBuilder:
             "medium": counts["MEDIUM"],
             "low": counts["LOW"],
             "info": counts["INFO"],
-            "good_practices": len(getattr(self.checker, "good_practices", [])),
+            "good_practices": len(self.checker.good_practices),
             "posture_score": score,
             "posture_rating": _rating_from_score(score, counts),
             "assessment_confidence": confidence["rating"],
@@ -456,13 +473,12 @@ class AssessmentBuilder:
             "assessment_type": ASSESSMENT_TYPE,
             "tool": {
                 "name": "Wilma",
-                "version": self._tool_version(),
+                "version": wilma.__version__,
             },
-            "account_id": getattr(self.checker, "account_id", None),
-            "region": getattr(self.checker, "region", None),
+            "account_id": self.checker.account_id,
+            "region": self.checker.region,
             "scan_time": datetime.now(timezone.utc).isoformat(),
-            "mode": getattr(getattr(self.checker, "mode", None), "value", "standard"),
-            "presentation_mode": getattr(self.checker, "presentation_mode", "standard"),
+            "mode": self.checker.mode.value,
             "posture_score": {
                 "score": score,
                 "rating": summary["posture_rating"],
@@ -481,17 +497,10 @@ class AssessmentBuilder:
             "summary": summary,
             "findings": normalized_findings,
             "filtered_findings": len(normalized_findings),
-            "total_findings_observed": len(getattr(self.checker, "findings", [])),
-            "good_practices": getattr(self.checker, "good_practices", []),
-            "available_models": getattr(self.checker, "available_models", []),
+            "total_findings_observed": len(self.checker.findings),
+            "good_practices": self.checker.good_practices,
+            "available_models": self.checker.available_models,
         }
-
-    def _tool_version(self) -> str:
-        try:
-            from wilma import __version__
-        except Exception:
-            return "unknown"
-        return __version__
 
     def _severity_counts(self, findings: list[dict[str, Any]]) -> dict[str, int]:
         counts = dict.fromkeys(SEVERITY_PENALTIES, 0)

--- a/src/wilma/checker.py
+++ b/src/wilma/checker.py
@@ -28,7 +28,7 @@ from wilma.checks import (
     NetworkSecurityChecks,
     TaggingSecurityChecks,
 )
-from wilma.config import WilmaConfig
+from wilma.config import AVAILABLE_CHECKS, WilmaConfig
 from wilma.enums import RiskLevel, SecurityMode
 from wilma.exceptions import WilmaCredentialsError
 
@@ -90,7 +90,6 @@ class BedrockSecurityChecker:
     def __init__(self, profile_name: str = None, region: str = None,
                  mode: SecurityMode = SecurityMode.STANDARD,
                  config: WilmaConfig = None,
-                 presentation_mode: str = "standard",
                  exit_on_error: bool = True):
         """
         Initialize checker with AWS credentials and check modules.
@@ -105,7 +104,6 @@ class BedrockSecurityChecker:
         """
         self.mode = mode
         self.config = config if config is not None else WilmaConfig()
-        self.presentation_mode = presentation_mode
 
         session_params = {}
         if profile_name:
@@ -238,9 +236,6 @@ class BedrockSecurityChecker:
 
     def _print_banner(self):
         """Display ASCII art banner with branding."""
-        if self.presentation_mode == "yabba_dabba_doo":
-            print("Yabba Dabba Doo! Wilma is rolling over the Bedrock...")
-
         banner = """
     ██╗    ██╗██╗██╗     ███╗   ███╗ █████╗
     ██║    ██║██║██║     ████╗ ████║██╔══██╗
@@ -270,28 +265,39 @@ class BedrockSecurityChecker:
                 self.findings.append(finding)
                 existing.add(key)
 
-    def _mark_assessed(self, check_name: str) -> None:
-        """Record which Bedrock Security Indicators had automated coverage."""
-        self.assessed_indicators.update(self.CHECK_INDICATORS.get(check_name, set()))
+    def _run_genai_checks(self) -> None:
+        """Run the GenAI threat checks (OWASP LLM Top 10)."""
+        self.genai_checks.check_prompt_injection_vulnerabilities()
+        self.genai_checks.check_data_privacy_compliance()
+        self.genai_checks.check_cost_anomaly_detection()
 
-    def _should_run_check(self, check_name: str) -> bool:
-        """Return whether a configured check module should run."""
-        return check_name in self.config.enabled_checks
+    def _check_runners(self) -> dict:
+        """
+        Map check-module names to runner callables.
+
+        Rich modules return module-local findings that must be merged into
+        checker.findings; legacy modules report through add_finding() directly.
+        """
+        return {
+            "agents": lambda: self._merge_module_findings(self.agent_checks.run_all_checks()),
+            "guardrails": lambda: self._merge_module_findings(self.guardrail_checks.run_all_checks()),
+            "knowledge_bases": lambda: self._merge_module_findings(self.kb_checks.run_all_checks()),
+            "fine_tuning": lambda: self._merge_module_findings(self.fine_tuning_checks.run_all_checks()),
+            "iam": self.iam_checks.check_model_access_audit,
+            "logging": self.logging_checks.check_logging_monitoring,
+            "network": self.network_checks.check_vpc_endpoints,
+            "tagging": self.tagging_checks.check_resource_tagging,
+            "genai": self._run_genai_checks,
+        }
 
     def run_all_checks(self) -> list[dict]:
         """
-        Execute all security checks in order.
+        Execute all enabled security checks in AVAILABLE_CHECKS order.
 
-        Runs comprehensive security audit covering:
-        1. Agents - 10 checks for autonomous AI systems (OWASP LLM08, LLM01)
-        2. Guardrails - 11 checks for content filtering & hallucination prevention (OWASP LLM01, LLM02, LLM09)
-        3. Knowledge Bases - 12 checks for RAG security (OWASP LLM03, LLM06, LLM07)
-        4. Fine-Tuning - 11 checks for training data security (OWASP LLM03, LLM04, LLM06)
-        5. IAM & Access Control - Who can use Bedrock and how
-        6. Logging & Monitoring - Audit trails and anomaly detection
-        7. Network Security - VPC endpoints and private connectivity
-        8. Resource Tagging - Organization and compliance tracking
-        9. GenAI Threats - OWASP LLM01 (prompt injection), PII leaks, cost abuse
+        Order matters: agents, guardrails, knowledge bases, and fine-tuning run
+        first because they provide the richest GenAI-specific context, followed
+        by the foundational IAM, logging, network, tagging, and GenAI threat
+        checks.
 
         Returns:
             List of finding dictionaries with risk levels and remediation steps
@@ -302,51 +308,10 @@ class BedrockSecurityChecker:
         print(f"Account: {self.account_id} | Region: {self.region}")
         print("=" * 60)
 
-        # Critical: Autonomous AI agents (OWASP LLM08: Excessive Agency)
-        if self._should_run_check("agents"):
-            self._merge_module_findings(self.agent_checks.run_all_checks())
-            self._mark_assessed("agents")
-
-        # Critical: Content filtering and hallucination prevention
-        if self._should_run_check("guardrails"):
-            self._merge_module_findings(self.guardrail_checks.run_all_checks())
-            self._mark_assessed("guardrails")
-
-        # Critical: RAG-specific security (data poisoning, PII, prompt injection)
-        if self._should_run_check("knowledge_bases"):
-            self._merge_module_findings(self.kb_checks.run_all_checks())
-            self._mark_assessed("knowledge_bases")
-
-        # Critical: Model fine-tuning security (training data protection, OWASP LLM03, LLM04, LLM06)
-        if self._should_run_check("fine_tuning"):
-            self._merge_module_findings(self.fine_tuning_checks.run_all_checks())
-            self._mark_assessed("fine_tuning")
-
-        # Foundation: Identity and access control
-        if self._should_run_check("iam"):
-            self.iam_checks.check_model_access_audit()
-            self._mark_assessed("iam")
-
-        # Visibility: Logging and monitoring
-        if self._should_run_check("logging"):
-            self.logging_checks.check_logging_monitoring()
-            self._mark_assessed("logging")
-
-        # Network: Private connectivity
-        if self._should_run_check("network"):
-            self.network_checks.check_vpc_endpoints()
-            self._mark_assessed("network")
-
-        # Organization: Resource management
-        if self._should_run_check("tagging"):
-            self.tagging_checks.check_resource_tagging()
-            self._mark_assessed("tagging")
-
-        # GenAI threats: OWASP LLM Top 10
-        if self._should_run_check("genai"):
-            self.genai_checks.check_prompt_injection_vulnerabilities()
-            self.genai_checks.check_data_privacy_compliance()
-            self.genai_checks.check_cost_anomaly_detection()
-            self._mark_assessed("genai")
+        runners = self._check_runners()
+        for check_name in AVAILABLE_CHECKS:
+            if check_name in self.config.enabled_checks:
+                runners[check_name]()
+                self.assessed_indicators.update(self.CHECK_INDICATORS[check_name])
 
         return self.findings

--- a/src/wilma/checks/agents.py
+++ b/src/wilma/checks/agents.py
@@ -29,7 +29,13 @@ from typing import Dict, List
 
 from botocore.exceptions import ClientError
 
-from wilma.utils import PII_PATTERNS, PROMPT_INJECTION_PATTERNS, handle_aws_error, paginate_aws_results
+from wilma.utils import (
+    PII_PATTERNS,
+    PROMPT_INJECTION_PATTERNS,
+    handle_aws_error,
+    paginate_aws_results,
+    statement_actions_resources,
+)
 
 from ..enums import RiskLevel
 
@@ -609,14 +615,7 @@ class AgentSecurityChecks:
                             if statement.get('Effect') != 'Allow':
                                 continue
 
-                            actions = statement.get('Action', [])
-                            resources = statement.get('Resource', [])
-
-                            # Convert to list if single string
-                            if isinstance(actions, str):
-                                actions = [actions]
-                            if isinstance(resources, str):
-                                resources = [resources]
+                            actions, resources = statement_actions_resources(statement)
 
                             # Check for wildcard actions with wildcard resources
                             has_wildcard_action = any(

--- a/src/wilma/checks/fine_tuning.py
+++ b/src/wilma/checks/fine_tuning.py
@@ -30,7 +30,7 @@ from typing import Dict, List
 from botocore.exceptions import ClientError
 
 from wilma.enums import RiskLevel
-from wilma.utils import PII_PATTERNS, handle_aws_error, paginate_aws_results
+from wilma.utils import PII_PATTERNS, handle_aws_error, paginate_aws_results, statement_actions_resources
 
 MAX_RESULTS_PER_PAGE = 100
 
@@ -585,10 +585,6 @@ class FineTuningSecurityChecks:
                 job_arn = job.get('jobArn', '')
 
                 try:
-                    self.bedrock.get_model_customization_job(
-                        jobIdentifier=job_arn
-                    )
-
                     # Check for CloudWatch log group
                     # Bedrock fine-tuning jobs typically log to /aws/bedrock/modelcustomizationjobs
                     log_group_name = '/aws/bedrock/modelcustomizationjobs'
@@ -848,9 +844,6 @@ class FineTuningSecurityChecks:
                     # Extract role name from ARN
                     role_name = role_arn.split('/')[-1]
 
-                    # Get role details
-                    self.iam.get_role(RoleName=role_name)
-
                     # Check attached policies
                     attached_policies = self.iam.list_attached_role_policies(RoleName=role_name)
 
@@ -899,9 +892,7 @@ class FineTuningSecurityChecks:
 
                                 for statement in statements:
                                     if statement.get('Effect') == 'Allow':
-                                        actions = statement.get('Action', [])
-                                        if isinstance(actions, str):
-                                            actions = [actions]
+                                        actions, _ = statement_actions_resources(statement)
 
                                         wildcard_actions = [a for a in actions if '*' in a]
                                         if wildcard_actions:
@@ -1041,15 +1032,12 @@ class FineTuningSecurityChecks:
                     if s3_uri:
                         bucket_name = s3_uri.replace('s3://', '').split('/')[0]
 
-                        # Try to determine bucket owner
                         try:
+                            # Confirm the bucket is reachable before flagging it;
+                            # inaccessible buckets are skipped rather than guessed at.
                             self.s3.get_bucket_location(Bucket=bucket_name)
 
-                            # Get current account ID
                             current_account = self.checker.account_id
-
-                            # Get bucket ACL to check owner
-                            self.s3.get_bucket_acl(Bucket=bucket_name)
 
                             # Check if bucket is in same account (basic validation)
                             # Note: This is a simplified check - in production, maintain allowlist
@@ -1120,41 +1108,31 @@ class FineTuningSecurityChecks:
                 model_arn = model.get('modelArn', '')
                 model_name = model.get('modelName', 'Unknown')
 
-                try:
-                    self.bedrock.get_custom_model(modelIdentifier=model_arn)
-
-                    # Check for description and documentation
-                    # Note: Bedrock may not have a dedicated model card field,
-                    # so we check for basic documentation via description or tags
-
-                    # Check if model has meaningful description
-                    # (In production, you'd define what constitutes "proper documentation")
-                    findings.append({
-                        'risk_level': RiskLevel.LOW,
-                        'title': 'Custom model documentation recommended',
-                        'description': (
-                            f'Custom model "{model_name}" should have comprehensive documentation. '
-                            f'Model cards help document intended use cases, limitations, training data sources, '
-                            f'and ethical considerations. This is important for governance and responsible AI practices.'
-                        ),
-                        'location': f'Custom Model: {model_name}',
-                        'resource': model_arn,
-                        'remediation': (
-                            'Document model details:\n'
-                            '1. Intended use cases and applications\n'
-                            '2. Training data sources and characteristics\n'
-                            '3. Known limitations and biases\n'
-                            '4. Performance metrics and evaluation results\n'
-                            '5. Ethical considerations and risk mitigations'
-                        ),
-                        'details': {
-                            'model_name': model_name,
-                            'recommendation': 'Create comprehensive model card'
-                        }
-                    })
-
-                except ClientError:
-                    pass
+                # Bedrock has no dedicated model card field, so every custom model
+                # gets a low-severity documentation reminder.
+                findings.append({
+                    'risk_level': RiskLevel.LOW,
+                    'title': 'Custom model documentation recommended',
+                    'description': (
+                        f'Custom model "{model_name}" should have comprehensive documentation. '
+                        f'Model cards help document intended use cases, limitations, training data sources, '
+                        f'and ethical considerations. This is important for governance and responsible AI practices.'
+                    ),
+                    'location': f'Custom Model: {model_name}',
+                    'resource': model_arn,
+                    'remediation': (
+                        'Document model details:\n'
+                        '1. Intended use cases and applications\n'
+                        '2. Training data sources and characteristics\n'
+                        '3. Known limitations and biases\n'
+                        '4. Performance metrics and evaluation results\n'
+                        '5. Ethical considerations and risk mitigations'
+                    ),
+                    'details': {
+                        'model_name': model_name,
+                        'recommendation': 'Create comprehensive model card'
+                    }
+                })
 
         except ClientError as e:
             handle_aws_error(e, "listing custom models")

--- a/src/wilma/checks/guardrails.py
+++ b/src/wilma/checks/guardrails.py
@@ -174,6 +174,8 @@ class GuardrailSecurityChecks:
                                 'location': f'Guardrail: {guardrail_name} (v{guardrail_version})',
                                 'resource': f'arn:aws:bedrock:*:*:guardrail/{guardrail_id}',
                                 'remediation': (
+                                    # "Update ... Set ..." is console guidance, not SQL;
+                                    # S608/B608 misfire on the wording.
                                     f'Update guardrail filter strength to HIGH:\n'  # noqa: S608  # nosec B608
                                     f'1. Navigate to AWS Bedrock console\n'
                                     f'2. Open Guardrails → "{guardrail_name}"\n'

--- a/src/wilma/checks/iam.py
+++ b/src/wilma/checks/iam.py
@@ -18,7 +18,7 @@ from typing import Dict, List
 from botocore.exceptions import ClientError
 
 from wilma.enums import RiskLevel, SecurityMode
-from wilma.utils import handle_aws_error, paginate_iam_results
+from wilma.utils import handle_aws_error, paginate_iam_results, statement_actions_resources
 
 
 class IAMSecurityChecks:
@@ -27,6 +27,15 @@ class IAMSecurityChecks:
     def __init__(self, checker):
         """Initialize with parent checker for AWS client access."""
         self.checker = checker
+        self._roles_cache = None
+
+    def _list_roles(self) -> List[Dict]:
+        """List IAM roles once and reuse across the role-based checks."""
+        if self._roles_cache is None:
+            self._roles_cache = list(
+                paginate_iam_results(self.checker.iam.list_roles, 'Roles', MaxItems=100)
+            )
+        return self._roles_cache
 
     def check_model_access_audit(self) -> List[Dict]:
         """Enhanced model access audit with beginner-friendly explanations."""
@@ -47,7 +56,6 @@ class IAMSecurityChecks:
             else:
                 for model in custom_models.get('modelSummaries', []):
                     model_name = model['modelName']
-                    model['modelArn']
 
                     # Check if model has proper access controls
                     try:
@@ -101,9 +109,7 @@ class IAMSecurityChecks:
 
                     for statement in policy_doc.get('Statement', []):
                         if statement.get('Effect') == 'Allow':
-                            actions = statement.get('Action', [])
-                            if isinstance(actions, str):
-                                actions = [actions]
+                            actions, _ = statement_actions_resources(statement)
 
                             # Check for dangerous Bedrock permissions
                             if any('bedrock:*' in action or action == '*' for action in actions):
@@ -141,7 +147,7 @@ class IAMSecurityChecks:
             risky_roles = []
 
             # List all IAM roles
-            for role in paginate_iam_results(self.checker.iam.list_roles, 'Roles', MaxItems=100):
+            for role in self._list_roles():
                 role_name = role['RoleName']
 
                 try:
@@ -189,9 +195,7 @@ class IAMSecurityChecks:
                                 # Check for wildcard actions
                                 for statement in policy_doc.get('Statement', []):
                                     if statement.get('Effect') == 'Allow':
-                                        actions = statement.get('Action', [])
-                                        if isinstance(actions, str):
-                                            actions = [actions]
+                                        actions, _ = statement_actions_resources(statement)
 
                                         if any('bedrock:*' in action or action == '*' for action in actions):
                                             self.checker.add_finding(
@@ -236,7 +240,7 @@ class IAMSecurityChecks:
         print("[CHECK] Checking IAM roles for cross-account access...")
 
         try:
-            for role in paginate_iam_results(self.checker.iam.list_roles, 'Roles', MaxItems=100):
+            for role in self._list_roles():
                 role_name = role['RoleName']
                 trust_policy = role.get('AssumeRolePolicyDocument', {})
                 statements = trust_policy.get('Statement', [])
@@ -280,7 +284,7 @@ class IAMSecurityChecks:
         print("[CHECK] Checking IAM role session durations...")
 
         try:
-            for role in paginate_iam_results(self.checker.iam.list_roles, 'Roles', MaxItems=100):
+            for role in self._list_roles():
                 role_name = role['RoleName']
                 max_session_duration = role.get('MaxSessionDuration', 3600)
 

--- a/src/wilma/checks/knowledge_bases.py
+++ b/src/wilma/checks/knowledge_bases.py
@@ -45,9 +45,19 @@ MAX_RESULTS_PER_PAGE = 100
 
 
 def _parse_policy_document(policy):
-    """OpenSearch Serverless returns policies as parsed documents; tolerate JSON strings too."""
+    """OpenSearch Serverless returns policies as parsed documents; tolerate JSON strings too.
+
+    Encryption policies are dicts (``{"Rules": [...], "AWSOwnedKey": ...}``) and
+    network/data-access policies are lists of rule objects. Returns [] for None
+    so callers iterating rules never raise TypeError.
+    """
     if isinstance(policy, str):
-        return json.loads(policy)
+        try:
+            return json.loads(policy)
+        except (json.JSONDecodeError, TypeError):
+            return []
+    if policy is None:
+        return []
     return policy
 
 
@@ -845,9 +855,12 @@ class KnowledgeBaseSecurityChecks:
                         if collection_name:
                             try:
                                 findings.extend(self._check_aoss_network_policies(kb_id, kb_name, collection_name))
+                            except Exception as e:
+                                print(f"[WARN] Could not check OpenSearch network policy for {collection_name}: {str(e)}")
+                            try:
                                 findings.extend(self._check_aoss_data_access_policies(kb_id, kb_name, collection_name))
                             except Exception as e:
-                                print(f"[WARN] Could not check OpenSearch collection {collection_name}: {str(e)}")
+                                print(f"[WARN] Could not check OpenSearch data access policy for {collection_name}: {str(e)}")
 
                     elif storage_type == 'RDS':
                         # Aurora/RDS - check for public accessibility

--- a/src/wilma/checks/knowledge_bases.py
+++ b/src/wilma/checks/knowledge_bases.py
@@ -30,12 +30,25 @@ from typing import Dict, List
 
 from botocore.exceptions import ClientError
 
-from wilma.utils import PII_PATTERNS, PROMPT_INJECTION_PATTERNS, handle_aws_error, paginate_aws_results
+from wilma.utils import (
+    PII_PATTERNS,
+    PROMPT_INJECTION_PATTERNS,
+    handle_aws_error,
+    paginate_aws_results,
+    statement_actions_resources,
+)
 
 from ..enums import RiskLevel
 
 # Constants
 MAX_RESULTS_PER_PAGE = 100
+
+
+def _parse_policy_document(policy):
+    """OpenSearch Serverless returns policies as parsed documents; tolerate JSON strings too."""
+    if isinstance(policy, str):
+        return json.loads(policy)
+    return policy
 
 
 class KnowledgeBaseSecurityChecks:
@@ -56,41 +69,8 @@ class KnowledgeBaseSecurityChecks:
         self.bedrock = checker.bedrock
         self.bedrock_agent = checker.session.client('bedrock-agent')
         self.s3 = checker.session.client('s3')
-        self.opensearch = checker.session.client('opensearch')
-        self.opensearchserverless = checker.session.client('opensearchserverless')
+        self.aoss = checker.session.client('opensearchserverless')
         self.findings = []
-
-    def __getattribute__(self, name):
-        attr = object.__getattribute__(self, name)
-        if name.startswith('check_') and callable(attr):
-            def synced_check(*args, **kwargs):
-                findings = attr(*args, **kwargs)
-                if isinstance(findings, list):
-                    self._sync_checker_findings(findings)
-                return findings
-
-            return synced_check
-        return attr
-
-    def _sync_checker_findings(self, findings):
-        """Keep direct check calls compatible with checker.findings."""
-        existing = {
-            (
-                str(finding.get('risk_level')),
-                finding.get('title') or finding.get('issue') or '',
-                finding.get('resource') or finding.get('location') or '',
-            )
-            for finding in self.checker.findings
-        }
-        for finding in findings:
-            key = (
-                str(finding.get('risk_level')),
-                finding.get('title') or finding.get('issue') or '',
-                finding.get('resource') or finding.get('location') or '',
-            )
-            if key not in existing:
-                self.checker.findings.append(finding)
-                existing.add(key)
 
     def _get_all_knowledge_bases(self) -> List[Dict]:
         """
@@ -116,6 +96,171 @@ class KnowledgeBaseSecurityChecks:
             print(f"[ERROR] Failed to list knowledge bases: {str(e)}")
 
         return knowledge_bases
+
+    def _get_aoss_security_policies(self, collection_name: str, policy_type: str) -> List[Dict]:
+        """
+        Return parsed OpenSearch Serverless security policies covering a collection.
+
+        Security policies cover encryption ('encryption') and network access ('network').
+        """
+        policies = []
+        summaries = self.aoss.list_security_policies(
+            type=policy_type,
+            resource=[f'collection/{collection_name}']
+        ).get('securityPolicySummaries', [])
+        for summary in summaries:
+            detail = self.aoss.get_security_policy(name=summary['name'], type=policy_type)
+            policies.append(_parse_policy_document(detail.get('securityPolicyDetail', {}).get('policy')))
+        return policies
+
+    def _get_aoss_data_access_policies(self, collection_name: str) -> List[Dict]:
+        """Return parsed OpenSearch Serverless data access policies covering a collection."""
+        policies = []
+        summaries = self.aoss.list_access_policies(
+            type='data',
+            resource=[f'collection/{collection_name}']
+        ).get('accessPolicySummaries', [])
+        for summary in summaries:
+            detail = self.aoss.get_access_policy(name=summary['name'], type='data')
+            policies.append(_parse_policy_document(detail.get('accessPolicyDetail', {}).get('policy')))
+        return policies
+
+    def _check_aoss_network_policies(self, kb_id: str, kb_name: str, collection_name: str) -> List[Dict]:
+        """Flag OpenSearch Serverless collections that are publicly reachable or unprotected."""
+        findings = []
+        policies = self._get_aoss_security_policies(collection_name, 'network')
+
+        if not policies:
+            findings.append({
+                'risk_level': RiskLevel.HIGH,
+                'title': 'Knowledge Base OpenSearch collection has no network policy',
+                'description': (
+                    f'Knowledge Base "{kb_name}" uses OpenSearch Serverless '
+                    f'collection "{collection_name}" which has no network access policy. '
+                    f'This may allow unrestricted access.'
+                ),
+                'location': f'Knowledge Base: {kb_name}',
+                'resource': collection_name,
+                'remediation': (
+                    f'Create network policy to restrict access:\n'
+                    f'aws opensearchserverless create-security-policy \\\n'
+                    f'  --name {collection_name}-network \\\n'
+                    f'  --type network \\\n'
+                    f'  --policy \'[{{"Rules":[{{"ResourceType":"collection",'
+                    f'"Resource":["collection/{collection_name}"]}}],'
+                    f'"AllowFromPublic":false,"SourceVPCEs":["your-vpc-endpoint"]}}]\''
+                ),
+                'details': {
+                    'knowledge_base_id': kb_id,
+                    'collection_name': collection_name,
+                    'network_policy': 'NONE'
+                }
+            })
+            return findings
+
+        for policy_json in policies:
+            for rule in policy_json:
+                if rule.get('AllowFromPublic', False):
+                    findings.append({
+                        'risk_level': RiskLevel.CRITICAL,
+                        'title': 'Knowledge Base OpenSearch collection allows public access',
+                        'description': (
+                            f'Knowledge Base "{kb_name}" uses OpenSearch Serverless '
+                            f'collection "{collection_name}" which allows public access. '
+                            f'This exposes your vector embeddings to potential unauthorized access.'
+                        ),
+                        'location': f'Knowledge Base: {kb_name}',
+                        'resource': collection_name,
+                        'remediation': (
+                            f'Update network policy to restrict access to VPC only:\n'
+                            f'aws opensearchserverless update-security-policy \\\n'
+                            f'  --name {collection_name}-network \\\n'
+                            f'  --type network \\\n'
+                            f'  --policy \'[{{"Rules":[{{"ResourceType":"collection",'
+                            f'"Resource":["collection/{collection_name}"]}}],'
+                            f'"AllowFromPublic":false,"SourceVPCEs":["your-vpc-endpoint"]}}]\''
+                        ),
+                        'details': {
+                            'knowledge_base_id': kb_id,
+                            'collection_name': collection_name,
+                            'public_access': True
+                        }
+                    })
+
+        return findings
+
+    def _check_aoss_data_access_policies(self, kb_id: str, kb_name: str, collection_name: str) -> List[Dict]:
+        """Flag missing or wildcard-permissive OpenSearch Serverless data access policies."""
+        findings = []
+        policies = self._get_aoss_data_access_policies(collection_name)
+
+        if not policies:
+            findings.append({
+                'risk_level': RiskLevel.HIGH,
+                'title': 'Knowledge Base OpenSearch collection has no data access policy',
+                'description': (
+                    f'Knowledge Base "{kb_name}" uses OpenSearch Serverless '
+                    f'collection "{collection_name}" which has no data access policy. '
+                    f'Collection may be inaccessible or have default overly permissive access.'
+                ),
+                'location': f'Knowledge Base: {kb_name}',
+                'resource': collection_name,
+                'remediation': (
+                    f'Create data access policy with least-privilege IAM principals:\n'
+                    f'aws opensearchserverless create-access-policy \\\n'
+                    f'  --name {collection_name}-data \\\n'
+                    f'  --type data \\\n'
+                    f'  --policy \'[{{"Rules":[{{"ResourceType":"index",'
+                    f'"Resource":["index/{collection_name}/*"],'
+                    f'"Permission":["aoss:ReadDocument","aoss:WriteDocument"]}}],'
+                    f'"Principal":["arn:aws:iam::ACCOUNT:role/KnowledgeBaseRole"]}}]\''
+                ),
+                'details': {
+                    'knowledge_base_id': kb_id,
+                    'collection_name': collection_name,
+                    'data_policy': 'NONE'
+                }
+            })
+            return findings
+
+        for policy_json in policies:
+            for rule in policy_json:
+                principals = rule.get('Principal', [])
+                if isinstance(principals, str):
+                    principals = [principals]
+
+                permissions = []
+                for policy_rule in rule.get('Rules', []):
+                    permissions.extend(policy_rule.get('Permission', []))
+
+                has_wildcard_principal = any(
+                    principal == '*' or ':*' in principal for principal in principals
+                )
+                if has_wildcard_principal or 'aoss:*' in permissions:
+                    findings.append({
+                        'risk_level': RiskLevel.CRITICAL,
+                        'title': 'Knowledge Base OpenSearch collection has overly permissive data access policy',
+                        'description': (
+                            f'Knowledge Base "{kb_name}" uses OpenSearch Serverless '
+                            f'collection "{collection_name}" with wildcard principals or '
+                            f'wildcard permissions. This can expose vector embeddings to '
+                            f'unintended access.'
+                        ),
+                        'location': f'Knowledge Base: {kb_name}',
+                        'resource': collection_name,
+                        'remediation': (
+                            'Restrict OpenSearch Serverless data access policies to specific '
+                            'IAM roles and minimum required aoss permissions.'
+                        ),
+                        'details': {
+                            'knowledge_base_id': kb_id,
+                            'collection_name': collection_name,
+                            'principals': principals,
+                            'permissions': permissions
+                        }
+                    })
+
+        return findings
 
     def check_s3_bucket_public_access(self) -> List[Dict]:
         """
@@ -521,54 +666,42 @@ class KnowledgeBaseSecurityChecks:
                         # OpenSearch Serverless - check collection ARN
                         oss_config = storage_config.get('opensearchServerlessConfiguration', {})
                         collection_arn = oss_config.get('collectionArn', '')
+                        collection_name = collection_arn.split('/')[-1] if '/' in collection_arn else None
 
-                        if collection_arn:
-                            collection_name = collection_arn.split('/')[-1] if '/' in collection_arn else None
+                        if collection_name:
+                            for policy_json in self._get_aoss_security_policies(collection_name, 'encryption'):
+                                uses_aws_owned_key = policy_json.get('AWSOwnedKey', False)
+                                rules = policy_json.get('Rules', [])
+                                has_customer_key = any(rule.get('KmsARN') for rule in rules)
 
-                            if collection_name:
-                                policy_response = self.opensearchserverless.get_security_policy(
-                                    name=collection_name,
-                                    type='encryption',
-                                )
-                                if isinstance(policy_response, dict):
-                                    policy_document = policy_response.get('securityPolicyDetail', {}).get('policy', '{}')
-                                    policy_json = json.loads(policy_document)
-                                    uses_aws_owned_key = policy_json.get('AWSOwnedKey', False)
-                                    rules = policy_json.get('Rules', [])
-                                    has_customer_key = any(rule.get('KmsARN') for rule in rules)
-
-                                    if uses_aws_owned_key or not has_customer_key:
-                                        findings.append({
-                                            'risk_level': RiskLevel.HIGH,
-                                            'title': 'Knowledge Base OpenSearch collection uses AWS-owned encryption key',
-                                            'description': (
-                                                f'Knowledge Base "{kb_name}" uses OpenSearch Serverless collection '
-                                                f'"{collection_name}" without a customer-managed KMS key. Customer-managed '
-                                                f'keys provide stronger auditability and access control for vector data.'
-                                            ),
-                                            'location': f'Knowledge Base: {kb_name}',
-                                            'resource': collection_name,
-                                            'remediation': (
-                                                'Configure the OpenSearch Serverless encryption policy to use a '
-                                                'customer-managed KMS key.'
-                                            ),
-                                            'details': {
-                                                'knowledge_base_id': kb_id,
-                                                'collection_name': collection_name,
-                                                'aws_owned_key': uses_aws_owned_key,
-                                                'customer_managed_key': has_customer_key
-                                            }
-                                        })
+                                if uses_aws_owned_key or not has_customer_key:
+                                    findings.append({
+                                        'risk_level': RiskLevel.HIGH,
+                                        'title': 'Knowledge Base OpenSearch collection uses AWS-owned encryption key',
+                                        'description': (
+                                            f'Knowledge Base "{kb_name}" uses OpenSearch Serverless collection '
+                                            f'"{collection_name}" without a customer-managed KMS key. Customer-managed '
+                                            f'keys provide stronger auditability and access control for vector data.'
+                                        ),
+                                        'location': f'Knowledge Base: {kb_name}',
+                                        'resource': collection_name,
+                                        'remediation': (
+                                            'Configure the OpenSearch Serverless encryption policy to use a '
+                                            'customer-managed KMS key.'
+                                        ),
+                                        'details': {
+                                            'knowledge_base_id': kb_id,
+                                            'collection_name': collection_name,
+                                            'aws_owned_key': uses_aws_owned_key,
+                                            'customer_managed_key': has_customer_key
+                                        }
+                                    })
 
                     elif storage_type == 'PINECONE':
-                        # Pinecone - managed service, check configuration
-                        storage_config.get('pineconeConfiguration', {})
                         # Pinecone encrypts at rest by default, but we note it
                         print(f"[INFO] Knowledge Base {kb_name} uses Pinecone (encrypted by default)")
 
                     elif storage_type == 'REDIS_ENTERPRISE_CLOUD':
-                        # Redis Enterprise Cloud - check configuration
-                        storage_config.get('redisEnterpriseCloudConfiguration', {})
                         # Redis Enterprise encrypts at rest, but we note it
                         print(f"[INFO] Knowledge Base {kb_name} uses Redis Enterprise (encrypted by default)")
 
@@ -704,240 +837,17 @@ class KnowledgeBaseSecurityChecks:
 
                     # Check based on storage type
                     if storage_type == 'OPENSEARCH_SERVERLESS':
-                        # OpenSearch Serverless - check collection access policy
+                        # OpenSearch Serverless - check network and data access policies
                         oss_config = storage_config.get('opensearchServerlessConfiguration', {})
                         collection_arn = oss_config.get('collectionArn', '')
+                        collection_name = collection_arn.split('/')[-1] if '/' in collection_arn else None
 
-                        if collection_arn:
-                            # Extract collection name from ARN
-                            collection_name = collection_arn.split('/')[-1] if '/' in collection_arn else None
-
-                            if collection_name:
-                                policy_getter = getattr(self.bedrock_agent, 'get_data_access_policy', None)
-                                if callable(policy_getter):
-                                    policy_response = policy_getter(name=collection_name, type='data')
-                                    if isinstance(policy_response, dict):
-                                        policy_document = (
-                                            policy_response
-                                            .get('accessPolicyDetail', {})
-                                            .get('policy', '[]')
-                                        )
-                                        policy_json = json.loads(policy_document)
-                                        for rule in policy_json:
-                                            principals = rule.get('Principal', [])
-                                            if isinstance(principals, str):
-                                                principals = [principals]
-
-                                            permissions = []
-                                            for policy_rule in rule.get('Rules', []):
-                                                permissions.extend(policy_rule.get('Permission', []))
-
-                                            if '*' in principals or 'aoss:*' in permissions:
-                                                findings.append({
-                                                    'risk_level': RiskLevel.CRITICAL,
-                                                    'title': 'Knowledge Base OpenSearch collection has overly permissive data access policy',
-                                                    'description': (
-                                                        f'Knowledge Base "{kb_name}" uses OpenSearch Serverless '
-                                                        f'collection "{collection_name}" with wildcard principals or '
-                                                        f'wildcard permissions. This can expose vector embeddings to '
-                                                        f'unintended access.'
-                                                    ),
-                                                    'location': f'Knowledge Base: {kb_name}',
-                                                    'resource': collection_name,
-                                                    'remediation': (
-                                                        'Restrict OpenSearch Serverless data access policies to specific '
-                                                        'IAM roles and minimum required aoss permissions.'
-                                                    ),
-                                                    'details': {
-                                                        'knowledge_base_id': kb_id,
-                                                        'collection_name': collection_name,
-                                                        'principals': principals,
-                                                        'permissions': permissions
-                                                    }
-                                                })
-
-                                try:
-                                    # Get collection details
-                                    aoss = self.checker.session.client('opensearchserverless')
-                                    collection_response = aoss.batch_get_collection(
-                                        names=[collection_name]
-                                    )
-
-                                    collections = collection_response.get('collectionDetails', [])
-
-                                    if collections:
-                                        collection = collections[0]
-                                        collection.get('type', '')
-
-                                        # OpenSearch Serverless collections should have VPC endpoints
-                                        # Check if collection has network access policy
-                                        try:
-                                            network_policy = aoss.get_access_policy(
-                                                name=f"{collection_name}-network",
-                                                type='network'
-                                            )
-
-                                            policy_detail = network_policy.get('accessPolicyDetail', {})
-                                            policy_document = policy_detail.get('policy', '')
-
-                                            # Parse policy to check for public access
-                                            if policy_document:
-                                                try:
-                                                    policy_json = json.loads(policy_document)
-                                                    # Check for AllowFromPublic rules
-                                                    for rule in policy_json:
-                                                        if rule.get('AllowFromPublic', False):
-                                                            findings.append({
-                                                                'risk_level': RiskLevel.CRITICAL,
-                                                                'title': 'Knowledge Base OpenSearch collection allows public access',
-                                                                'description': (
-                                                                    f'Knowledge Base "{kb_name}" uses OpenSearch Serverless '
-                                                                    f'collection "{collection_name}" which allows public access. '
-                                                                    f'This exposes your vector embeddings to potential unauthorized access.'
-                                                                ),
-                                                                'location': f'Knowledge Base: {kb_name}',
-                                                                'resource': collection_name,
-                                                                'remediation': (
-                                                                    f'Update network policy to restrict access to VPC only:\n'
-                                                                    f'aws opensearchserverless update-access-policy \\\n'
-                                                                    f'  --name {collection_name}-network \\\n'
-                                                                    f'  --type network \\\n'
-                                                                    f'  --policy \'[{{"Rules":[{{"ResourceType":"collection",'
-                                                                    f'"Resource":["collection/{collection_name}"]}}],'
-                                                                    f'"AllowFromPublic":false,"SourceVPCEs":["your-vpc-endpoint"]}}]\''
-                                                                ),
-                                                                'details': {
-                                                                    'knowledge_base_id': kb_id,
-                                                                    'collection_name': collection_name,
-                                                                    'public_access': True
-                                                                }
-                                                            })
-
-                                                except json.JSONDecodeError:
-                                                    print(f"[WARN] Could not parse network policy for collection {collection_name}")
-
-                                        except aoss.exceptions.ResourceNotFoundException:
-                                            # No network policy - potentially public
-                                            findings.append({
-                                                'risk_level': RiskLevel.HIGH,
-                                                'title': 'Knowledge Base OpenSearch collection has no network policy',
-                                                'description': (
-                                                    f'Knowledge Base "{kb_name}" uses OpenSearch Serverless '
-                                                    f'collection "{collection_name}" which has no network access policy. '
-                                                    f'This may allow unrestricted access.'
-                                                ),
-                                                'location': f'Knowledge Base: {kb_name}',
-                                                'resource': collection_name,
-                                                'remediation': (
-                                                    f'Create network policy to restrict access:\n'
-                                                    f'aws opensearchserverless create-access-policy \\\n'
-                                                    f'  --name {collection_name}-network \\\n'
-                                                    f'  --type network \\\n'
-                                                    f'  --policy \'[{{"Rules":[{{"ResourceType":"collection",'
-                                                    f'"Resource":["collection/{collection_name}"]}}],'
-                                                    f'"AllowFromPublic":false,"SourceVPCEs":["your-vpc-endpoint"]}}]\''
-                                                ),
-                                                'details': {
-                                                    'knowledge_base_id': kb_id,
-                                                    'collection_name': collection_name,
-                                                    'network_policy': 'NONE'
-                                                }
-                                            })
-
-                                        # Check data access policy (in addition to network policy)
-                                        try:
-                                            data_policy = aoss.get_access_policy(
-                                                name=f"{collection_name}-data",
-                                                type='data'
-                                            )
-
-                                            policy_detail = data_policy.get('accessPolicyDetail', {})
-                                            policy_document = policy_detail.get('policy', '')
-
-                                            # Parse data access policy
-                                            if policy_document:
-                                                try:
-                                                    policy_json = json.loads(policy_document)
-
-                                                    # Check for overly permissive principals
-                                                    has_wildcard_principal = False
-                                                    for rule in policy_json:
-                                                        principals = rule.get('Principal', [])
-                                                        if isinstance(principals, str):
-                                                            principals = [principals]
-
-                                                        # Check for wildcards in principals
-                                                        for principal in principals:
-                                                            if principal == '*' or ':*' in principal:
-                                                                has_wildcard_principal = True
-                                                                break
-
-                                                    if has_wildcard_principal:
-                                                        findings.append({
-                                                            'risk_level': RiskLevel.HIGH,
-                                                            'title': 'Knowledge Base OpenSearch collection has overly permissive data access policy',
-                                                            'description': (
-                                                                f'Knowledge Base "{kb_name}" uses OpenSearch Serverless '
-                                                                f'collection "{collection_name}" with a data access policy '
-                                                                f'that grants access to wildcard principals. This may allow '
-                                                                f'unintended IAM principals to access your vector embeddings.'
-                                                            ),
-                                                            'location': f'Knowledge Base: {kb_name}',
-                                                            'resource': collection_name,
-                                                            'remediation': (
-                                                                f'Update data access policy to specific IAM principals:\n'
-                                                                f'aws opensearchserverless update-access-policy \\\n'
-                                                                f'  --name {collection_name}-data \\\n'
-                                                                f'  --type data \\\n'
-                                                                f'  --policy \'[{{"Rules":[{{"ResourceType":"index",'
-                                                                f'"Resource":["index/{collection_name}/*"],'
-                                                                f'"Permission":["aoss:ReadDocument","aoss:WriteDocument"]}}],'
-                                                                f'"Principal":["arn:aws:iam::ACCOUNT:role/SpecificRole"]}}]\''
-                                                            ),
-                                                            'details': {
-                                                                'knowledge_base_id': kb_id,
-                                                                'collection_name': collection_name,
-                                                                'issue': 'Wildcard principals in data access policy'
-                                                            }
-                                                        })
-
-                                                except json.JSONDecodeError:
-                                                    print(f"[WARN] Could not parse data access policy for collection {collection_name}")
-
-                                        except aoss.exceptions.ResourceNotFoundException:
-                                            # No data access policy
-                                            findings.append({
-                                                'risk_level': RiskLevel.HIGH,
-                                                'title': 'Knowledge Base OpenSearch collection has no data access policy',
-                                                'description': (
-                                                    f'Knowledge Base "{kb_name}" uses OpenSearch Serverless '
-                                                    f'collection "{collection_name}" which has no data access policy. '
-                                                    f'Collection may be inaccessible or have default overly permissive access.'
-                                                ),
-                                                'location': f'Knowledge Base: {kb_name}',
-                                                'resource': collection_name,
-                                                'remediation': (
-                                                    f'Create data access policy with least-privilege IAM principals:\n'
-                                                    f'aws opensearchserverless create-access-policy \\\n'
-                                                    f'  --name {collection_name}-data \\\n'
-                                                    f'  --type data \\\n'
-                                                    f'  --policy \'[{{"Rules":[{{"ResourceType":"index",'
-                                                    f'"Resource":["index/{collection_name}/*"],'
-                                                    f'"Permission":["aoss:ReadDocument","aoss:WriteDocument"]}}],'
-                                                    f'"Principal":["arn:aws:iam::ACCOUNT:role/KnowledgeBaseRole"]}}]\''
-                                                ),
-                                                'details': {
-                                                    'knowledge_base_id': kb_id,
-                                                    'collection_name': collection_name,
-                                                    'data_policy': 'NONE'
-                                                }
-                                            })
-
-                                        except Exception as e:
-                                            print(f"[WARN] Could not check data access policy for {collection_name}: {str(e)}")
-
-                                except Exception as e:
-                                    print(f"[WARN] Could not check OpenSearch collection {collection_name}: {str(e)}")
+                        if collection_name:
+                            try:
+                                findings.extend(self._check_aoss_network_policies(kb_id, kb_name, collection_name))
+                                findings.extend(self._check_aoss_data_access_policies(kb_id, kb_name, collection_name))
+                            except Exception as e:
+                                print(f"[WARN] Could not check OpenSearch collection {collection_name}: {str(e)}")
 
                     elif storage_type == 'RDS':
                         # Aurora/RDS - check for public accessibility
@@ -1509,10 +1419,6 @@ class KnowledgeBaseSecurityChecks:
 
                         if role_name:
                             try:
-                                # Get role policies
-                                role_response = self.checker.iam.get_role(RoleName=role_name)
-                                role_response.get('Role', {})
-
                                 # Check attached policies
                                 attached_policies_response = self.checker.iam.list_attached_role_policies(
                                     RoleName=role_name
@@ -1569,12 +1475,7 @@ class KnowledgeBaseSecurityChecks:
                                             if statement.get('Effect') != 'Allow':
                                                 continue
 
-                                            actions = statement.get('Action', [])
-                                            resources = statement.get('Resource', [])
-                                            if isinstance(actions, str):
-                                                actions = [actions]
-                                            if isinstance(resources, str):
-                                                resources = [resources]
+                                            actions, resources = statement_actions_resources(statement)
 
                                             has_service_wildcard = any(action == '*' or action.endswith(':*') for action in actions)
                                             has_wildcard_resource = any(resource == '*' for resource in resources)
@@ -1623,13 +1524,7 @@ class KnowledgeBaseSecurityChecks:
                                         # Check for overly permissive actions
                                         for statement in policy_doc.get('Statement', []):
                                             if statement.get('Effect') == 'Allow':
-                                                actions = statement.get('Action', [])
-                                                if isinstance(actions, str):
-                                                    actions = [actions]
-
-                                                resources = statement.get('Resource', [])
-                                                if isinstance(resources, str):
-                                                    resources = [resources]
+                                                actions, resources = statement_actions_resources(statement)
 
                                                 # Check for dangerous wildcard permissions
                                                 has_wildcard_action = any(action == '*' for action in actions)
@@ -1739,7 +1634,6 @@ class KnowledgeBaseSecurityChecks:
 
                         data_source_config = ds_details.get('dataSource', {})
                         ds_config = data_source_config.get('dataSourceConfiguration', {})
-                        ds_config.get('s3Configuration', {})
 
                         # Check chunking strategy
                         chunking_config = (
@@ -2295,14 +2189,7 @@ class KnowledgeBaseSecurityChecks:
                             if statement.get('Effect') != 'Allow':
                                 continue
 
-                            actions = statement.get('Action', [])
-                            resources = statement.get('Resource', [])
-
-                            # Convert to list if single string
-                            if isinstance(actions, str):
-                                actions = [actions]
-                            if isinstance(resources, str):
-                                resources = [resources]
+                            actions, resources = statement_actions_resources(statement)
 
                             # Check for bedrock:InvokeModel or bedrock:* with wildcard resources
                             has_invoke_model = any(

--- a/src/wilma/checks/logging.py
+++ b/src/wilma/checks/logging.py
@@ -30,6 +30,21 @@ class LoggingSecurityChecks:
         """Initialize with parent checker for AWS client access."""
         self.checker = checker
 
+    def _get_invocation_logging_config(self) -> Dict:
+        """Return the Bedrock model invocation logging configuration."""
+        response = self.checker.bedrock.get_model_invocation_logging_configuration()
+        return response.get('loggingConfig', {})
+
+    def _get_log_group(self, log_group_name: str) -> Dict:
+        """Return the CloudWatch log group matching a name exactly, or an empty dict."""
+        log_groups = self.checker.cloudwatch.describe_log_groups(
+            logGroupNamePrefix=log_group_name
+        ).get('logGroups', [])
+        for log_group in log_groups:
+            if log_group.get('logGroupName') == log_group_name:
+                return log_group
+        return {}
+
     def check_logging_monitoring(self) -> List[Dict]:
         """Enhanced logging check with beginner-friendly explanations."""
         if self.checker.mode == SecurityMode.LEARN:
@@ -42,9 +57,9 @@ class LoggingSecurityChecks:
 
         try:
             # Check model invocation logging
-            logging_config = self.checker.bedrock.get_model_invocation_logging_configuration()
+            config = self._get_invocation_logging_config()
 
-            if not logging_config.get('loggingConfig'):
+            if not config:
                 self.checker.add_finding(
                     risk_level=RiskLevel.HIGH,
                     category="Audit & Compliance",
@@ -59,7 +74,6 @@ class LoggingSecurityChecks:
                 self.checker.add_good_practice("Audit & Compliance", "Model invocation logging is enabled")
 
                 # Check if both CloudWatch and S3 logging are enabled
-                config = logging_config['loggingConfig']
                 if not config.get('cloudWatchConfig', {}).get('logGroupName'):
                     self.checker.add_finding(
                         risk_level=RiskLevel.MEDIUM,
@@ -90,21 +104,14 @@ class LoggingSecurityChecks:
         print("[CHECK] Checking CloudWatch log retention for Bedrock invocations...")
 
         try:
-            logging_config = self.checker.bedrock.get_model_invocation_logging_configuration()
-            cloudwatch_config = logging_config.get('loggingConfig', {}).get('cloudWatchConfig', {})
+            cloudwatch_config = self._get_invocation_logging_config().get('cloudWatchConfig', {})
             log_group_name = cloudwatch_config.get('logGroupName')
 
             if not log_group_name:
                 return self.checker.findings
 
-            log_groups = self.checker.cloudwatch.describe_log_groups(
-                logGroupNamePrefix=log_group_name
-            ).get('logGroups', [])
-
-            for log_group in log_groups:
-                if log_group.get('logGroupName') != log_group_name:
-                    continue
-
+            log_group = self._get_log_group(log_group_name)
+            if log_group:
                 retention_days = log_group.get('retentionInDays')
                 if retention_days is not None and retention_days < self.checker.config.log_retention_days:
                     self.checker.add_finding(
@@ -133,25 +140,20 @@ class LoggingSecurityChecks:
         print("[CHECK] Checking Bedrock log encryption...")
 
         try:
-            logging_config = self.checker.bedrock.get_model_invocation_logging_configuration()
-            config = logging_config.get('loggingConfig', {})
+            config = self._get_invocation_logging_config()
 
-            cloudwatch_config = config.get('cloudWatchConfig', {})
-            log_group_name = cloudwatch_config.get('logGroupName')
+            log_group_name = config.get('cloudWatchConfig', {}).get('logGroupName')
             if log_group_name:
-                log_groups = self.checker.cloudwatch.describe_log_groups(
-                    logGroupNamePrefix=log_group_name
-                ).get('logGroups', [])
-                for log_group in log_groups:
-                    if log_group.get('logGroupName') == log_group_name and not log_group.get('kmsKeyId'):
-                        self.checker.add_finding(
-                            risk_level=RiskLevel.HIGH,
-                            category="Audit & Compliance",
-                            resource=f"CloudWatch Log Group: {log_group_name}",
-                            issue="Bedrock CloudWatch logs are not encrypted with a customer-managed KMS key",
-                            recommendation="Associate a customer-managed KMS key with the log group",
-                            technical_details="CloudWatch log group has no kmsKeyId"
-                        )
+                log_group = self._get_log_group(log_group_name)
+                if log_group and not log_group.get('kmsKeyId'):
+                    self.checker.add_finding(
+                        risk_level=RiskLevel.HIGH,
+                        category="Audit & Compliance",
+                        resource=f"CloudWatch Log Group: {log_group_name}",
+                        issue="Bedrock CloudWatch logs are not encrypted with a customer-managed KMS key",
+                        recommendation="Associate a customer-managed KMS key with the log group",
+                        technical_details="CloudWatch log group has no kmsKeyId"
+                    )
 
             s3_config = config.get('s3Config', {})
             bucket_name = s3_config.get('bucketName')

--- a/src/wilma/checks/network.py
+++ b/src/wilma/checks/network.py
@@ -54,8 +54,8 @@ class NetworkSecurityChecks:
                 endpoint_id = endpoint.get('VpcEndpointId', '')
                 state = endpoint.get('State', '')
 
-                # Ignore deleted/failed endpoints, but include pending endpoints for local tests
-                # and newly-created resources that still need configuration validation.
+                # Ignore endpoints in terminal states. Pending endpoints are still
+                # validated because they will serve traffic once available.
                 if state in ['deleted', 'failed', 'deleting']:
                     continue
 

--- a/src/wilma/config.py
+++ b/src/wilma/config.py
@@ -18,6 +18,21 @@ import yaml
 
 from wilma.enums import RiskLevel
 
+# Canonical ordered list of check modules. Order matters for contextual checks
+# (agents and guardrails inform later checks); the checker runs modules in
+# this order and validation accepts only these names.
+AVAILABLE_CHECKS = (
+    'agents',
+    'guardrails',
+    'knowledge_bases',
+    'fine_tuning',
+    'iam',
+    'logging',
+    'network',
+    'tagging',
+    'genai',
+)
+
 
 class WilmaConfig:
     """Configuration manager for Wilma posture assessment checks."""
@@ -34,17 +49,7 @@ class WilmaConfig:
             'min_risk_level': 'LOW'
         },
         'checks': {
-            'enabled': [
-                'agents',
-                'guardrails',
-                'knowledge_bases',
-                'fine_tuning',
-                'iam',
-                'logging',
-                'network',
-                'tagging',
-                'genai',
-            ]
+            'enabled': list(AVAILABLE_CHECKS)
         }
     }
 
@@ -151,27 +156,26 @@ class WilmaConfig:
             self.config['output']['min_risk_level'] = min_risk
 
         # Validate enabled checks
-        valid_checks = [
-            'agents',
-            'guardrails',
-            'knowledge_bases',
-            'fine_tuning',
-            'iam',
-            'logging',
-            'network',
-            'tagging',
-            'genai',
-        ]
         enabled = self.config['checks'].get('enabled', [])
         if not isinstance(enabled, list):
             print("[WARN] Invalid 'enabled' checks configuration, using all checks")
-            self.config['checks']['enabled'] = valid_checks
+            self.config['checks']['enabled'] = list(AVAILABLE_CHECKS)
         else:
             # Filter out invalid check names
-            invalid_checks = [c for c in enabled if c not in valid_checks]
+            invalid_checks = [c for c in enabled if c not in AVAILABLE_CHECKS]
             if invalid_checks:
                 print(f"[WARN] Unknown checks ignored: {', '.join(invalid_checks)}")
-            self.config['checks']['enabled'] = [c for c in enabled if c in valid_checks]
+            self.config['checks']['enabled'] = [c for c in enabled if c in AVAILABLE_CHECKS]
+
+    def set_enabled_checks(self, check_names: list) -> None:
+        """Replace the enabled check modules, dropping unknown names with a warning."""
+        self.config['checks']['enabled'] = check_names
+        self._validate_config()
+
+    def set_min_risk_level(self, level: str) -> None:
+        """Set the minimum risk level filter, falling back to LOW if invalid."""
+        self.config['output']['min_risk_level'] = level
+        self._validate_config()
 
     # ========================================================================
     # Configuration Accessors

--- a/src/wilma/reports.py
+++ b/src/wilma/reports.py
@@ -25,6 +25,30 @@ from wilma.assessment import (
 )
 from wilma.enums import RiskLevel
 
+# Presentation themes change terminal styling only; evidence, scores, JSON
+# output, and exit codes are identical across themes.
+REPORT_THEMES = {
+    "standard": {
+        "title": "WILMA BEDROCK SECURITY POSTURE ASSESSMENT",
+        "subtitle": "AWS Bedrock security best-practice and framework-mapped assessment",
+        "border_style": "cyan",
+        "score_title": "Posture Summary",
+        "score_label": "Bedrock Security Posture: {rating} ({score}/100)",
+        "footer_note": None,
+    },
+    "yabba_dabba_doo": {
+        "title": "WILMA'S BEDROCK STONE TABLET",
+        "subtitle": "Yabba Dabba Doo mode - same evidence, more fun",
+        "border_style": "magenta",
+        "score_title": "Stone Tablet Summary",
+        "score_label": "Fred, your Bedrock Security Posture is {rating} ({score}/100)",
+        "footer_note": (
+            "Yabba Dabba Doo mode changed presentation only; "
+            "evidence, score, and exit codes are unchanged."
+        ),
+    },
+}
+
 
 class ReportGenerator:
     """
@@ -36,7 +60,7 @@ class ReportGenerator:
 
     def __init__(self, checker=None, presentation_mode: str = "standard", emit: bool = True):
         self.checker = checker
-        self.presentation_mode = presentation_mode
+        self.theme = REPORT_THEMES[presentation_mode]
         self._buffer = None if emit else io.StringIO()
         self.console = Console(file=self._buffer or sys.stdout, record=True)
 
@@ -67,18 +91,10 @@ class ReportGenerator:
         confidence = assessment["assessment_confidence"]
         summary = assessment["summary"]
 
-        if self.presentation_mode == "yabba_dabba_doo":
-            title = "WILMA'S BEDROCK STONE TABLET"
-            subtitle = "Yabba Dabba Doo mode - same evidence, more fun"
-            border_style = "magenta"
-        else:
-            title = "WILMA BEDROCK SECURITY POSTURE ASSESSMENT"
-            subtitle = "AWS Bedrock security best-practice and framework-mapped assessment"
-            border_style = "cyan"
-
+        border_style = self.theme["border_style"]
         header_text = Text()
-        header_text.append(f"{title}\n", style=f"bold {border_style}")
-        header_text.append(subtitle, style="dim")
+        header_text.append(f"{self.theme['title']}\n", style=f"bold {border_style}")
+        header_text.append(self.theme["subtitle"], style="dim")
         self.console.print(Panel(header_text, box=box.DOUBLE, border_style=border_style, padding=(1, 2)))
 
         self._print_account_context(assessment)
@@ -87,7 +103,7 @@ class ReportGenerator:
         self._print_good_practices(assessment["good_practices"])
         self._print_findings(assessment["findings"])
         self._print_manual_evidence(assessment["manual_evidence_needed"])
-        self._print_footer(assessment)
+        self._print_footer()
 
     def _print_account_context(self, assessment: dict[str, Any]):
         info_table = Table.grid(padding=(0, 2))
@@ -101,14 +117,9 @@ class ReportGenerator:
         self.console.print()
 
     def _print_score_summary(self, score: dict[str, Any], confidence: dict[str, Any], summary: dict[str, Any]):
-        if self.presentation_mode == "yabba_dabba_doo":
-            score_title = "Stone Tablet Summary"
-            score_label = f"Fred, your Bedrock Security Posture is {score['rating']} ({score['score']}/100)"
-        else:
-            score_title = "Posture Summary"
-            score_label = f"Bedrock Security Posture: {score['rating']} ({score['score']}/100)"
+        score_label = self.theme["score_label"].format(rating=score["rating"], score=score["score"])
 
-        score_table = Table(title=score_title, box=box.ROUNDED, show_header=True, header_style="bold cyan")
+        score_table = Table(title=self.theme["score_title"], box=box.ROUNDED, show_header=True, header_style="bold cyan")
         score_table.add_column("Metric", style="bold", width=28)
         score_table.add_column("Value", width=68)
         score_table.add_row("Posture Score", score_label)
@@ -246,15 +257,15 @@ class ReportGenerator:
         ))
         self.console.print()
 
-    def _print_footer(self, assessment: dict[str, Any]):
+    def _print_footer(self):
         tips = Text.from_markup(
             "[bold]Next Steps:[/bold]\n"
             "  - Fix critical and high findings first\n"
             "  - Use [cyan]--explain[/cyan] for the scoring and framework model\n"
             "  - Use [cyan]--output json[/cyan] for CI, GRC ingestion, or dashboards\n"
         )
-        if self.presentation_mode == "yabba_dabba_doo":
-            tips.append("\nYabba Dabba Doo mode changed presentation only; evidence, score, and exit codes are unchanged.", style="dim italic")
+        if self.theme["footer_note"]:
+            tips.append(f"\n{self.theme['footer_note']}", style="dim italic")
 
         self.console.print(Panel(tips, title="Next Steps", border_style="dim", box=box.ROUNDED))
 

--- a/src/wilma/utils.py
+++ b/src/wilma/utils.py
@@ -159,6 +159,26 @@ def extract_resource_from_arn(arn: str, default: Optional[str] = None) -> Option
 
 
 # ============================================================================
+# IAM POLICY UTILITIES
+# ============================================================================
+
+def statement_actions_resources(statement: Dict[str, Any]) -> tuple:
+    """
+    Return (actions, resources) from an IAM policy statement, normalized to lists.
+
+    IAM allows both string and list values for Action and Resource; every
+    wildcard scan needs them as lists.
+    """
+    actions = statement.get('Action', [])
+    if isinstance(actions, str):
+        actions = [actions]
+    resources = statement.get('Resource', [])
+    if isinstance(resources, str):
+        resources = [resources]
+    return actions, resources
+
+
+# ============================================================================
 # PAGINATION UTILITIES
 # ============================================================================
 

--- a/src/wilma/utils.py
+++ b/src/wilma/utils.py
@@ -167,12 +167,13 @@ def statement_actions_resources(statement: Dict[str, Any]) -> tuple:
     Return (actions, resources) from an IAM policy statement, normalized to lists.
 
     IAM allows both string and list values for Action and Resource; every
-    wildcard scan needs them as lists.
+    wildcard scan needs them as lists. JSON null values are coerced to []
+    so downstream iteration never raises TypeError.
     """
-    actions = statement.get('Action', [])
+    actions = statement.get('Action') or []
     if isinstance(actions, str):
         actions = [actions]
-    resources = statement.get('Resource', [])
+    resources = statement.get('Resource') or []
     if isinstance(resources, str):
         resources = [resources]
     return actions, resources

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,25 @@ def mock_bedrock_agent_client():
     return mock_client
 
 
+@pytest.fixture
+def mock_aoss_client():
+    """
+    Create a MagicMock for the OpenSearch Serverless (aoss) client.
+
+    Defaults to "no policies found" so tests opt in to specific policy shapes.
+    """
+    mock_client = MagicMock()
+
+    mock_client.list_security_policies.return_value = {
+        'securityPolicySummaries': []
+    }
+    mock_client.list_access_policies.return_value = {
+        'accessPolicySummaries': []
+    }
+
+    return mock_client
+
+
 # ============================================================================
 # Moto Fixtures for fully-supported services
 # ============================================================================
@@ -134,11 +153,11 @@ def moto_ec2(aws_credentials):
 # ============================================================================
 
 @pytest.fixture
-def mock_checker(aws_credentials, mock_bedrock_client, mock_bedrock_agent_client):
+def mock_checker(aws_credentials, mock_bedrock_client, mock_bedrock_agent_client, mock_aoss_client):
     """
     Create a BedrockSecurityChecker with hybrid mocking.
 
-    - Bedrock clients use MagicMock (incomplete Moto support)
+    - Bedrock and OpenSearch Serverless clients use MagicMock (incomplete Moto support)
     - S3, IAM, EC2, Logs use Moto (full support)
 
     This is the main fixture for integration tests.
@@ -154,7 +173,7 @@ def mock_checker(aws_credentials, mock_bedrock_client, mock_bedrock_agent_client
         checker.bedrock = mock_bedrock_client
         checker.bedrock_agent = mock_bedrock_agent_client
 
-        # Mock session.client to return our mocked bedrock-agent client
+        # Mock session.client to return our mocked Bedrock/aoss clients
         original_session_client = checker.session.client
 
         def mock_session_client(service_name, **kwargs):
@@ -162,6 +181,8 @@ def mock_checker(aws_credentials, mock_bedrock_client, mock_bedrock_agent_client
                 return mock_bedrock_agent_client
             elif service_name == 'bedrock':
                 return mock_bedrock_client
+            elif service_name == 'opensearchserverless':
+                return mock_aoss_client
             else:
                 # For other services (s3, iam, etc.), use Moto
                 return original_session_client(service_name, **kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,6 @@ class FakeChecker:
         self.account_id = "123456789012"
         self.region = "us-east-1"
         self.mode = kwargs["mode"]
-        self.presentation_mode = "standard"
         self.findings = [
             {
                 "risk_level": RiskLevel.HIGH,
@@ -27,6 +26,9 @@ class FakeChecker:
         self.visibility_gaps = []
 
     def run_all_checks(self):
+        return self.findings
+
+    def filtered_findings(self):
         return self.findings
 
 

--- a/tests/test_assessment.py
+++ b/tests/test_assessment.py
@@ -51,23 +51,25 @@ def test_normalize_rich_finding_preserves_evidence_details():
 
 
 def test_assessment_builder_separates_posture_score_and_manual_evidence():
+    findings = [
+        {
+            "risk_level": RiskLevel.HIGH,
+            "category": "Network Security",
+            "resource": "VPC Endpoint: bedrock-runtime",
+            "issue": "AI model invocation traffic goes over the public internet",
+            "recommendation": "Create a VPC endpoint for private model invocations",
+        }
+    ]
     checker = SimpleNamespace(
         account_id="123456789012",
         region="us-east-1",
         mode=SecurityMode.STANDARD,
-        presentation_mode="standard",
-        findings=[
-            {
-                "risk_level": RiskLevel.HIGH,
-                "category": "Network Security",
-                "resource": "VPC Endpoint: bedrock-runtime",
-                "issue": "AI model invocation traffic goes over the public internet",
-                "recommendation": "Create a VPC endpoint for private model invocations",
-            }
-        ],
+        findings=findings,
+        filtered_findings=lambda: findings,
         good_practices=[],
         available_models=[],
         assessed_indicators={"network_runtime_isolation"},
+        visibility_gaps=[],
     )
 
     assessment = AssessmentBuilder(checker).build()
@@ -103,12 +105,12 @@ def test_assessment_builder_uses_filtered_findings_when_available():
         account_id="123456789012",
         region="us-east-1",
         mode=SecurityMode.STANDARD,
-        presentation_mode="standard",
         findings=all_findings,
         filtered_findings=lambda: [all_findings[1]],
         good_practices=[],
         available_models=[],
         assessed_indicators={"monitoring_logging_detection", "governance_inventory"},
+        visibility_gaps=[],
     )
 
     assessment = AssessmentBuilder(checker).build()
@@ -124,8 +126,8 @@ def test_visibility_gaps_reduce_assessment_confidence():
         account_id="123456789012",
         region="us-east-1",
         mode=SecurityMode.STANDARD,
-        presentation_mode="standard",
         findings=[],
+        filtered_findings=lambda: [],
         good_practices=[],
         available_models=[],
         assessed_indicators={

--- a/tests/test_kb_checks.py
+++ b/tests/test_kb_checks.py
@@ -100,7 +100,7 @@ class TestKBDataSourceEncryption:
 class TestKBVectorStoreEncryption:
     """Test Knowledge Base vector store encryption checks."""
 
-    def test_unencrypted_opensearch_collection(self, mock_checker):
+    def test_unencrypted_opensearch_collection(self, mock_checker, mock_aoss_client):
         """Test detection of unencrypted OpenSearch Serverless collections."""
         # Configure Bedrock Agent mock with unencrypted OpenSearch config
         storage_config = {
@@ -121,12 +121,14 @@ class TestKBVectorStoreEncryption:
             storage_config=storage_config
         )
 
-        # Mock OpenSearch Serverless to return unencrypted collection
-        kb_checks = KnowledgeBaseSecurityChecks(mock_checker)
-        kb_checks.opensearchserverless.get_security_policy = lambda **kwargs: {
+        # Mock OpenSearch Serverless to return an AWS-owned-key encryption policy
+        mock_aoss_client.list_security_policies.return_value = {
+            'securityPolicySummaries': [{'name': 'test-collection-encryption'}]
+        }
+        mock_aoss_client.get_security_policy.return_value = {
             'securityPolicyDetail': {
                 'type': 'encryption',
-                'policy': json.dumps({
+                'policy': {
                     'Rules': [
                         {
                             'Resource': ['collection/test-collection'],
@@ -134,18 +136,19 @@ class TestKBVectorStoreEncryption:
                         }
                     ],
                     'AWSOwnedKey': True
-                })
+                }
             }
         }
 
         # Run check
+        kb_checks = KnowledgeBaseSecurityChecks(mock_checker)
         findings = kb_checks.check_vector_store_encryption()
 
         # Verify HIGH finding for AWS-owned key (not customer-managed)
         high_findings = [f for f in findings if f.get('risk_level') == RiskLevel.HIGH]
         assert len(high_findings) > 0
 
-    def test_encrypted_opensearch_collection(self, mock_checker):
+    def test_encrypted_opensearch_collection(self, mock_checker, mock_aoss_client):
         """Test that encrypted OpenSearch collections pass validation."""
         # Configure Bedrock Agent mock with encrypted OpenSearch config
         storage_config = {
@@ -166,12 +169,14 @@ class TestKBVectorStoreEncryption:
             storage_config=storage_config
         )
 
-        # Mock OpenSearch Serverless to return encrypted collection with customer key
-        kb_checks = KnowledgeBaseSecurityChecks(mock_checker)
-        kb_checks.opensearchserverless.get_security_policy = lambda **kwargs: {
+        # Mock OpenSearch Serverless to return a customer-managed-key encryption policy
+        mock_aoss_client.list_security_policies.return_value = {
+            'securityPolicySummaries': [{'name': 'test-collection-encryption'}]
+        }
+        mock_aoss_client.get_security_policy.return_value = {
             'securityPolicyDetail': {
                 'type': 'encryption',
-                'policy': json.dumps({
+                'policy': {
                     'Rules': [
                         {
                             'Resource': ['collection/test-collection'],
@@ -179,15 +184,16 @@ class TestKBVectorStoreEncryption:
                             'KmsARN': 'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012'
                         }
                     ]
-                })
+                }
             }
         }
 
         # Run check
-        kb_checks.check_vector_store_encryption()
+        kb_checks = KnowledgeBaseSecurityChecks(mock_checker)
+        findings = kb_checks.check_vector_store_encryption()
 
         # Verify no HIGH findings (collection uses customer-managed key)
-        high_findings = [f for f in mock_checker.findings if f.get('risk_level') == RiskLevel.HIGH]
+        high_findings = [f for f in findings if f.get('risk_level') == RiskLevel.HIGH]
         assert len(high_findings) == 0
 
 
@@ -450,7 +456,7 @@ class TestKBPIIDetection:
 class TestKBOpenSearchAccessPolicies:
     """Test Knowledge Base OpenSearch access policy checks."""
 
-    def test_overly_permissive_data_access_policy(self, mock_checker):
+    def test_overly_permissive_data_access_policy(self, mock_checker, mock_aoss_client):
         """Test detection of overly permissive data access policies."""
         # Configure Bedrock Agent mock
         storage_config = {
@@ -467,17 +473,20 @@ class TestKBOpenSearchAccessPolicies:
         )
 
         # Mock overly permissive data access policy
-        mock_checker.bedrock_agent.get_data_access_policy = lambda **kwargs: {
+        mock_aoss_client.list_access_policies.return_value = {
+            'accessPolicySummaries': [{'name': 'test-collection-data'}]
+        }
+        mock_aoss_client.get_access_policy.return_value = {
             'accessPolicyDetail': {
                 'type': 'data',
-                'policy': json.dumps([{
+                'policy': [{
                     'Rules': [{
                         'Resource': ['collection/test-collection'],
                         'Permission': ['aoss:*'],
                         'ResourceType': 'collection'
                     }],
                     'Principal': ['*']
-                }])
+                }]
             }
         }
 
@@ -489,7 +498,7 @@ class TestKBOpenSearchAccessPolicies:
         critical_findings = [f for f in findings if f.get('risk_level') == RiskLevel.CRITICAL]
         assert len(critical_findings) > 0
 
-    def test_restrictive_data_access_policy(self, mock_checker):
+    def test_restrictive_data_access_policy(self, mock_checker, mock_aoss_client):
         """Test that restrictive data access policies pass validation."""
         # Configure Bedrock Agent mock
         storage_config = {
@@ -506,26 +515,29 @@ class TestKBOpenSearchAccessPolicies:
         )
 
         # Mock restrictive data access policy
-        mock_checker.bedrock_agent.get_data_access_policy = lambda **kwargs: {
+        mock_aoss_client.list_access_policies.return_value = {
+            'accessPolicySummaries': [{'name': 'test-collection-data'}]
+        }
+        mock_aoss_client.get_access_policy.return_value = {
             'accessPolicyDetail': {
                 'type': 'data',
-                'policy': json.dumps([{
+                'policy': [{
                     'Rules': [{
                         'Resource': ['collection/test-collection'],
                         'Permission': ['aoss:ReadDocument', 'aoss:WriteDocument'],
                         'ResourceType': 'collection'
                     }],
                     'Principal': ['arn:aws:iam::123456789012:role/SpecificKBRole']
-                }])
+                }]
             }
         }
 
         # Run check
         kb_checks = KnowledgeBaseSecurityChecks(mock_checker)
-        kb_checks.check_vector_store_access_control()
+        findings = kb_checks.check_vector_store_access_control()
 
         # Verify no CRITICAL findings (policy is restrictive)
-        critical_findings = [f for f in mock_checker.findings if f.get('risk_level') == RiskLevel.CRITICAL]
+        critical_findings = [f for f in findings if f.get('risk_level') == RiskLevel.CRITICAL]
         assert len(critical_findings) == 0
 
 

--- a/tests/test_kb_checks.py
+++ b/tests/test_kb_checks.py
@@ -540,6 +540,40 @@ class TestKBOpenSearchAccessPolicies:
         critical_findings = [f for f in findings if f.get('risk_level') == RiskLevel.CRITICAL]
         assert len(critical_findings) == 0
 
+    def test_aoss_policy_returned_as_none_does_not_crash(self, mock_checker, mock_aoss_client):
+        """A None policy document should not raise TypeError when iterating rules."""
+        storage_config = {
+            'type': 'OPENSEARCH_SERVERLESS',
+            'opensearchServerlessConfiguration': {
+                'collectionArn': 'arn:aws:aoss:us-east-1:123456789012:collection/test-collection'
+            }
+        }
+        setup_knowledge_base_mock(
+            mock_checker.bedrock_agent,
+            kb_id='kb-123',
+            kb_name='TestKB',
+            storage_config=storage_config
+        )
+
+        # AOSS returns a policy entry but the policy document itself is None.
+        mock_aoss_client.list_security_policies.return_value = {
+            'securityPolicySummaries': [{'name': 'test-collection-network'}]
+        }
+        mock_aoss_client.get_security_policy.return_value = {
+            'securityPolicyDetail': {'type': 'network', 'policy': None}
+        }
+        mock_aoss_client.list_access_policies.return_value = {
+            'accessPolicySummaries': [{'name': 'test-collection-data'}]
+        }
+        mock_aoss_client.get_access_policy.return_value = {
+            'accessPolicyDetail': {'type': 'data', 'policy': None}
+        }
+
+        kb_checks = KnowledgeBaseSecurityChecks(mock_checker)
+        # Should not raise; missing-policy path reports HIGH findings instead.
+        findings = kb_checks.check_vector_store_access_control()
+        assert isinstance(findings, list)
+
 
 class TestKBPublicAccess:
     """Test Knowledge Base S3 public access checks."""

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -8,20 +8,21 @@ from wilma.reports import ReportGenerator
 
 
 def _fake_checker():
+    findings = [
+        {
+            "risk_level": RiskLevel.HIGH,
+            "category": "Audit & Compliance",
+            "resource": "Model Invocation Logging",
+            "issue": "Logging disabled",
+            "recommendation": "Enable model invocation logging",
+        }
+    ]
     return SimpleNamespace(
         account_id="123456789012",
         region="us-east-1",
         mode=SecurityMode.STANDARD,
-        presentation_mode="standard",
-        findings=[
-            {
-                "risk_level": RiskLevel.HIGH,
-                "category": "Audit & Compliance",
-                "resource": "Model Invocation Logging",
-                "issue": "Logging disabled",
-                "recommendation": "Enable model invocation logging",
-            }
-        ],
+        findings=findings,
+        filtered_findings=lambda: findings,
         good_practices=[
             {
                 "category": "Logging",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from wilma.utils import (
     parse_arn,
     scan_text_for_pii,
     scan_text_for_prompt_injection,
+    statement_actions_resources,
     validate_resource_tags,
 )
 
@@ -190,3 +191,31 @@ class TestTagValidation:
         """Test normalizing None."""
         result = normalize_boto3_tags(None)
         assert result == {}
+
+
+class TestStatementActionsResources:
+    """Test IAM statement Action/Resource normalization."""
+
+    def test_string_values_become_lists(self):
+        actions, resources = statement_actions_resources(
+            {"Action": "s3:GetObject", "Resource": "arn:aws:s3:::bucket/*"}
+        )
+        assert actions == ["s3:GetObject"]
+        assert resources == ["arn:aws:s3:::bucket/*"]
+
+    def test_list_values_are_preserved(self):
+        actions, resources = statement_actions_resources(
+            {"Action": ["s3:GetObject", "s3:PutObject"], "Resource": ["arn:aws:s3:::a", "arn:aws:s3:::b"]}
+        )
+        assert actions == ["s3:GetObject", "s3:PutObject"]
+        assert resources == ["arn:aws:s3:::a", "arn:aws:s3:::b"]
+
+    def test_null_values_become_empty_lists(self):
+        actions, resources = statement_actions_resources({"Action": None, "Resource": None})
+        assert actions == []
+        assert resources == []
+
+    def test_missing_keys_become_empty_lists(self):
+        actions, resources = statement_actions_resources({})
+        assert actions == []
+        assert resources == []


### PR DESCRIPTION
## Summary

Fixes all findings from a deep code quality audit of the `fc5d1c0` posture-assessment reboot, rebased onto the current `main` (0.2.1 library API, visibility gaps, `filtered_findings`).

### Blockers fixed
- **Phantom OpenSearch checks**: the KB vector-store encryption, network-policy, and data-access checks previously probed the `bedrock-agent` client for `get_collection_security_policy` / `get_data_access_policy` via `getattr`. Those operations do not exist on that client, so the checks silently skipped against real AWS and only executed under test mocks. They now use the real `opensearchserverless` APIs (`list_security_policies` / `list_access_policies` filtered by collection resource, then `get_security_policy` / `get_access_policy`). This also fixes network policies being fetched as access policies (a nonexistent type) and policy lookup by a `{collection}-network`/`-data` naming convention.
- **`__getattribute__` magic removed**: deleted the attribute-access interceptor and `_sync_checker_findings` in `KnowledgeBaseSecurityChecks`; `checker._merge_module_findings` is now the single dedup/merge path (the two had divergent dedup keys).

### Structural cleanups
- Check-module registry consolidated: `AVAILABLE_CHECKS` in `config.py` is the single canonical name list; `run_all_checks` is a loop over a runner map instead of nine copied if-blocks.
- `presentation_mode` confined to a theme table in `reports.py`; removed from the checker and the JSON assessment, restoring the documented invariant that yabba mode never changes JSON. Duplicate banner line removed.
- Legacy findings classified by a deterministic category-to-indicator map before keyword fallback; `risk_level_label` simplified by pinning the enum invariant at the producer; `AssessmentBuilder` uses an explicit checker contract instead of `getattr` fallbacks.
- New public `WilmaConfig.set_enabled_checks` / `set_min_risk_level` replace the CLI reaching into `_validate_config`.
- Shared `statement_actions_resources` helper replaces IAM Action/Resource normalization copied across four modules; logging config/log-group fetch helpers; `list_roles` cached across IAM role checks; result-discarding AWS calls deleted in `fine_tuning`/`iam`/`knowledge_bases`.

### Validation
- 154 passed, 2 skipped
- ruff clean, bandit clean
- coverage 56% (gate: 50%)
- `wilma --explain` smoke-tested

### Follow-up (intentionally not in this PR)
Splitting `knowledge_bases.py` (2.3k lines) into a `vector_stores` module: the clean version changes the user-facing `--checks` registry, so it deserves its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer configuration for selecting security checks and minimum risk levels.
  * Improved assessment reporting with tool version information and more consistent finding categorization.
  * Expanded OpenSearch Serverless checks for encryption, network access, and data access policies.
  * Added theme-driven report presentation with tailored labels and footer guidance.

* **Bug Fixes**
  * Improved IAM permission analysis and reduced redundant role lookups.
  * Refined logging, fine-tuning, training data, and model documentation checks for more reliable results.
  * Improved handling of legacy findings and policy formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->