### PR TITLE
Fix OpenSearch policy assessment regressions

### DIFF
--- a/src/wilma/assessment.py
+++ b/src/wilma/assessment.py
@@ -273,8 +273,10 @@ def risk_level_label(value: Any) -> str:
     """Return a stable severity label from RiskLevel enums or severity strings."""
     if isinstance(value, RiskLevel):
         return value.label
-    if isinstance(value, str) and value.upper() in SEVERITY_PENALTIES:
-        return value.upper()
+    if isinstance(value, str):
+        label = value.rsplit(".", 1)[-1].upper()
+        if label in SEVERITY_PENALTIES:
+            return label
     return "INFO"
 
 

--- a/src/wilma/checks/knowledge_bases.py
+++ b/src/wilma/checks/knowledge_bases.py
@@ -26,7 +26,7 @@ Threat Coverage:
 
 import json
 import re
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from botocore.exceptions import ClientError
 
@@ -114,10 +114,14 @@ class KnowledgeBaseSecurityChecks:
         Security policies cover encryption ('encryption') and network access ('network').
         """
         policies = []
-        summaries = self.aoss.list_security_policies(
+        summaries = paginate_aws_results(
+            self.aoss.list_security_policies,
+            'securityPolicySummaries',
+            token_key='nextToken',  # noqa: S106
+            token_param='nextToken',  # noqa: S106
             type=policy_type,
-            resource=[f'collection/{collection_name}']
-        ).get('securityPolicySummaries', [])
+            resource=[f'collection/{collection_name}'],
+        )
         for summary in summaries:
             detail = self.aoss.get_security_policy(name=summary['name'], type=policy_type)
             policies.append(_parse_policy_document(detail.get('securityPolicyDetail', {}).get('policy')))
@@ -126,14 +130,27 @@ class KnowledgeBaseSecurityChecks:
     def _get_aoss_data_access_policies(self, collection_name: str) -> List[Dict]:
         """Return parsed OpenSearch Serverless data access policies covering a collection."""
         policies = []
-        summaries = self.aoss.list_access_policies(
+        summaries = paginate_aws_results(
+            self.aoss.list_access_policies,
+            'accessPolicySummaries',
+            token_key='nextToken',  # noqa: S106
+            token_param='nextToken',  # noqa: S106
             type='data',
-            resource=[f'collection/{collection_name}']
-        ).get('accessPolicySummaries', [])
+            resource=[f'collection/{collection_name}'],
+        )
         for summary in summaries:
             detail = self.aoss.get_access_policy(name=summary['name'], type='data')
             policies.append(_parse_policy_document(detail.get('accessPolicyDetail', {}).get('policy')))
         return policies
+
+    def _get_aoss_collection_name(self, collection_arn: str) -> Optional[str]:
+        """Resolve the collection name from a Bedrock storage configuration ARN."""
+        if '/' not in collection_arn:
+            return None
+        collection_id = collection_arn.rsplit('/', 1)[-1]
+        response = self.aoss.batch_get_collection(ids=[collection_id])
+        details = response.get('collectionDetails', [])
+        return details[0].get('name') if details else None
 
     def _check_aoss_network_policies(self, kb_id: str, kb_name: str, collection_name: str) -> List[Dict]:
         """Flag OpenSearch Serverless collections that are publicly reachable or unprotected."""
@@ -676,13 +693,12 @@ class KnowledgeBaseSecurityChecks:
                         # OpenSearch Serverless - check collection ARN
                         oss_config = storage_config.get('opensearchServerlessConfiguration', {})
                         collection_arn = oss_config.get('collectionArn', '')
-                        collection_name = collection_arn.split('/')[-1] if '/' in collection_arn else None
+                        collection_name = self._get_aoss_collection_name(collection_arn)
 
                         if collection_name:
                             for policy_json in self._get_aoss_security_policies(collection_name, 'encryption'):
                                 uses_aws_owned_key = policy_json.get('AWSOwnedKey', False)
-                                rules = policy_json.get('Rules', [])
-                                has_customer_key = any(rule.get('KmsARN') for rule in rules)
+                                has_customer_key = bool(policy_json.get('KmsARN'))
 
                                 if uses_aws_owned_key or not has_customer_key:
                                     findings.append({
@@ -850,7 +866,7 @@ class KnowledgeBaseSecurityChecks:
                         # OpenSearch Serverless - check network and data access policies
                         oss_config = storage_config.get('opensearchServerlessConfiguration', {})
                         collection_arn = oss_config.get('collectionArn', '')
-                        collection_name = collection_arn.split('/')[-1] if '/' in collection_arn else None
+                        collection_name = self._get_aoss_collection_name(collection_arn)
 
                         if collection_name:
                             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,9 @@ def mock_aoss_client():
     mock_client.list_access_policies.return_value = {
         'accessPolicySummaries': []
     }
+    mock_client.batch_get_collection.return_value = {
+        'collectionDetails': [{'id': 'test-collection', 'name': 'test-collection'}]
+    }
 
     return mock_client
 

--- a/tests/test_assessment.py
+++ b/tests/test_assessment.py
@@ -27,6 +27,21 @@ def test_normalize_legacy_finding_maps_to_bsi_and_frameworks():
     assert normalized["issue"] == "AI model usage is not being logged"
 
 
+def test_normalize_serialized_legacy_risk_level():
+    finding = {
+        "risk_level": "RiskLevel.HIGH",
+        "category": "Audit & Compliance",
+        "resource": "Model Invocation Logging",
+        "issue": "AI model usage is not being logged",
+        "recommendation": "Enable model invocation logging",
+    }
+
+    normalized = normalize_finding(finding, 1)
+
+    assert normalized["severity"] == "HIGH"
+    assert normalized["risk_score"] == RiskLevel.HIGH.score
+
+
 def test_normalize_rich_finding_preserves_evidence_details():
     finding = {
         "risk_level": RiskLevel.CRITICAL,

--- a/tests/test_kb_checks.py
+++ b/tests/test_kb_checks.py
@@ -106,7 +106,7 @@ class TestKBVectorStoreEncryption:
         storage_config = {
             'type': 'OPENSEARCH_SERVERLESS',
             'opensearchServerlessConfiguration': {
-                'collectionArn': 'arn:aws:aoss:us-east-1:123456789012:collection/test-collection',
+                'collectionArn': 'arn:aws:aoss:us-east-1:123456789012:collection/abc123collectionid',
                 'fieldMapping': {
                     'vectorField': 'bedrock-knowledge-base-default-vector',
                     'textField': 'AMAZON_BEDROCK_TEXT_CHUNK',
@@ -124,6 +124,9 @@ class TestKBVectorStoreEncryption:
         # Mock OpenSearch Serverless to return an AWS-owned-key encryption policy
         mock_aoss_client.list_security_policies.return_value = {
             'securityPolicySummaries': [{'name': 'test-collection-encryption'}]
+        }
+        mock_aoss_client.batch_get_collection.return_value = {
+            'collectionDetails': [{'id': 'abc123collectionid', 'name': 'test-collection'}]
         }
         mock_aoss_client.get_security_policy.return_value = {
             'securityPolicyDetail': {
@@ -147,6 +150,11 @@ class TestKBVectorStoreEncryption:
         # Verify HIGH finding for AWS-owned key (not customer-managed)
         high_findings = [f for f in findings if f.get('risk_level') == RiskLevel.HIGH]
         assert len(high_findings) > 0
+        mock_aoss_client.batch_get_collection.assert_called_once_with(ids=['abc123collectionid'])
+        mock_aoss_client.list_security_policies.assert_called_once_with(
+            type='encryption',
+            resource=['collection/test-collection'],
+        )
 
     def test_encrypted_opensearch_collection(self, mock_checker, mock_aoss_client):
         """Test that encrypted OpenSearch collections pass validation."""
@@ -180,10 +188,10 @@ class TestKBVectorStoreEncryption:
                     'Rules': [
                         {
                             'Resource': ['collection/test-collection'],
-                            'ResourceType': 'collection',
-                            'KmsARN': 'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012'
+                            'ResourceType': 'collection'
                         }
-                    ]
+                    ],
+                    'KmsARN': 'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012'
                 }
             }
         }
@@ -195,6 +203,28 @@ class TestKBVectorStoreEncryption:
         # Verify no HIGH findings (collection uses customer-managed key)
         high_findings = [f for f in findings if f.get('risk_level') == RiskLevel.HIGH]
         assert len(high_findings) == 0
+
+    def test_security_policy_lookup_paginates(self, mock_checker, mock_aoss_client):
+        """Test that OpenSearch Serverless policy lookup follows nextToken."""
+        mock_aoss_client.list_security_policies.side_effect = [
+            {
+                'securityPolicySummaries': [{'name': 'first'}],
+                'nextToken': 'page-2',
+            },
+            {
+                'securityPolicySummaries': [{'name': 'second'}],
+            },
+        ]
+        mock_aoss_client.get_security_policy.side_effect = [
+            {'securityPolicyDetail': {'policy': {'AWSOwnedKey': True}}},
+            {'securityPolicyDetail': {'policy': {'AWSOwnedKey': False, 'KmsARN': 'key-arn'}}},
+        ]
+
+        kb_checks = KnowledgeBaseSecurityChecks(mock_checker)
+        policies = kb_checks._get_aoss_security_policies('test-collection', 'encryption')
+
+        assert len(policies) == 2
+        assert mock_aoss_client.list_security_policies.call_args_list[1].kwargs['nextToken'] == 'page-2'
 
 
 class TestKBChunkingConfiguration:


### PR DESCRIPTION
## Summary

- resolve OpenSearch Serverless collection IDs to collection names before policy lookup
- read customer-managed KMS keys from the correct encryption-policy field
- paginate AOSS security and access policy listings
- preserve serialized legacy risk-level labels
- add regression coverage for each behavior

## Validation

- `ruff check` passes
- Python compilation passes
- pytest was unavailable in the local environment