### PR TITLE
Drop Python 3.9 support, apply deferred dependency updates, release 0.2.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.2]
+
+### Changed
+- Dropped Python 3.9 support (end-of-life October 2025); Wilma now requires Python 3.10+
+- Raised dependency floors: boto3/botocore >=1.43.51
+- Raised dev tooling floors: pytest >=9.1.1, moto >=5.2.2, types-PyYAML >=6.0.12.20260518, build >=1.5.0, ruff >=0.15.22, boto3-stubs >=1.43.51, pre-commit >=4.6.0, ipython >=8.39.0
+- Bumped CI actions: github/codeql-action to v4.37.1, actions/setup-python to v6.3.0
+
 ## [0.2.1]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Wilma is an AWS Bedrock Security Posture Assessment tool. It evaluates AWS Bedro
 The active reboot version line is `0.2.x` beta. Historical public `1.x` packages are treated as legacy pre-reboot releases.
 
 **Key Technologies:**
-- Python 3.9+ (support for 3.9, 3.10, 3.11, 3.12, 3.13)
+- Python 3.10+ (support for 3.10, 3.11, 3.12, 3.13)
 - boto3/botocore for AWS API access
 - Rich library for terminal UI
 - pytest with moto for testing
@@ -259,7 +259,7 @@ Two critical security patterns in `utils.py`:
 ### GitHub Actions Workflows
 
 **test.yml** (runs on push/PR):
-- Tests all Python versions (3.9-3.13)
+- Tests all Python versions (3.10-3.13)
 - Runs: ruff, bandit, mypy, pytest with coverage
 - Uploads coverage reports (from Python 3.11 only)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ wilma --help
 
 ### CI/CD Integration
 All pull requests automatically run:
-- **Tests** across Python 3.9, 3.10, 3.11, 3.12, 3.13
+- **Tests** across Python 3.10, 3.11, 3.12, 3.13
 - **Linting** with ruff
 - **Security scanning** with bandit
 - **Type checking** with mypy

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/wilma-sec.svg)](https://pypi.org/project/wilma-sec/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Security Audit](https://img.shields.io/badge/Security-Audit%20Tool-red)](https://github.com/ethanolivertroy/wilma)
 [![OWASP](https://img.shields.io/badge/OWASP-LLM%20Top%2010-darkblue)](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 [![AWS](https://img.shields.io/badge/AWS-Bedrock%20Security-orange)](https://aws.amazon.com/bedrock/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wilma-sec"
-version = "0.2.1"
+version = "0.2.2"
 description = "Wilma - AWS Bedrock Security Posture Assessment"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "GPL-3.0-or-later"
 authors = [
     {name = "Ethan Troy"},
@@ -21,7 +21,6 @@ classifiers = [
     "Topic :: Security",
     "Topic :: System :: Systems Administration",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -30,8 +29,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "boto3>=1.42.97,<2.0.0",
-    "botocore>=1.42.97,<2.0.0",
+    "boto3>=1.43.51,<2.0.0",
+    "botocore>=1.43.51,<2.0.0",
     "rich>=15.0.0,<16.0.0",
     "pyyaml>=6.0.3,<7.0.0",
 ]
@@ -52,16 +51,16 @@ where = ["src"]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0.0",
+    "pytest>=9.1.1",
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.15.1",
-    "moto>=5.0.0",
+    "moto>=5.2.2",
     "ruff>=0.15.22",
     "bandit[toml]>=1.8.6",
     "mypy>=1.19.1,<2.0.0",
     "boto3-stubs[bedrock]>=1.43.51",
-    "types-PyYAML>=6.0.0",
-    "build>=1.4.4",
+    "types-PyYAML>=6.0.12.20260518",
+    "build>=1.5.0",
     "twine>=6.2.0",
     "tomli>=2.0.0; python_version<'3.11'",  # For reading pyproject.toml in publish workflow
 ]
@@ -69,7 +68,7 @@ dev = [
 # Ruff configuration - Fast Python linter
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [
@@ -112,7 +111,7 @@ skips = [
 
 # MyPy configuration - Type checking
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false  # Set to true once types are added

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 # Testing dependencies
-pytest>=8.0.0
+pytest>=9.1.1
 pytest-cov>=4.1.0
 pytest-mock>=3.15.1
 pytest-xdist>=3.8.0  # Parallel test execution
-moto[bedrock,s3,iam,ec2,logs]>=5.0.0  # Realistic AWS service mocking
+moto[bedrock,s3,iam,ec2,logs]>=5.2.2  # Realistic AWS service mocking
 
 # Code quality and linting
 ruff>=0.15.22
@@ -15,10 +15,10 @@ bandit[toml]>=1.8.6
 # Type checking
 mypy>=1.19.1,<2.0.0
 boto3-stubs[bedrock]>=1.43.51
-types-PyYAML>=6.0.0
+types-PyYAML>=6.0.12.20260518
 
 # Build and packaging
-build>=1.4.4
+build>=1.5.0
 twine>=6.2.0
 
 # Development utilities

--- a/src/wilma/__init__.py
+++ b/src/wilma/__init__.py
@@ -12,7 +12,7 @@ the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "Ethan Troy"
 __license__ = "GPL-3.0-or-later"
 

--- a/src/wilma/api.py
+++ b/src/wilma/api.py
@@ -1,7 +1,6 @@
 """Embeddable library API for Wilma scans."""
 
 from dataclasses import dataclass
-from typing import Optional
 
 from wilma.assessment import AssessmentBuilder
 from wilma.checker import BedrockSecurityChecker
@@ -23,9 +22,9 @@ class WilmaScanner:
 
     def __init__(
         self,
-        profile: Optional[str] = None,
-        region: Optional[str] = None,
-        config: Optional[WilmaConfig] = None,
+        profile: str | None = None,
+        region: str | None = None,
+        config: WilmaConfig | None = None,
         mode: SecurityMode = SecurityMode.STANDARD,
     ):
         self.profile = profile

--- a/src/wilma/checks/guardrails.py
+++ b/src/wilma/checks/guardrails.py
@@ -26,7 +26,7 @@ MITRE ATLAS: AML.T0051 (LLM Prompt Injection), AML.T0048 (Evade ML Model)
 Compliance: SOC 2, ISO 27001, GDPR Art. 32, HIPAA, PCI-DSS
 """
 
-from typing import Dict, List, Union
+from typing import Dict, List
 
 from botocore.exceptions import ClientError
 
@@ -48,7 +48,7 @@ class GuardrailSecurityChecks:
         self.bedrock = checker.bedrock
         self.findings = []
 
-    def _record_visibility_gap(self, operation: str, error: Union[Exception, str]) -> None:
+    def _record_visibility_gap(self, operation: str, error: Exception | str) -> None:
         """Record API visibility gaps so assessment confidence reflects partial scans."""
         recorder = getattr(self.checker, "record_visibility_gap", None)
         if callable(recorder):

--- a/src/wilma/checks/knowledge_bases.py
+++ b/src/wilma/checks/knowledge_bases.py
@@ -26,7 +26,7 @@ Threat Coverage:
 
 import json
 import re
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from botocore.exceptions import ClientError
 
@@ -143,7 +143,7 @@ class KnowledgeBaseSecurityChecks:
             policies.append(_parse_policy_document(detail.get('accessPolicyDetail', {}).get('policy')))
         return policies
 
-    def _get_aoss_collection_name(self, collection_arn: str) -> Optional[str]:
+    def _get_aoss_collection_name(self, collection_arn: str) -> str | None:
         """Resolve the collection name from a Bedrock storage configuration ARN."""
         if '/' not in collection_arn:
             return None

--- a/src/wilma/config.py
+++ b/src/wilma/config.py
@@ -12,7 +12,7 @@ the Free Software Foundation, either version 3 of the License, or
 import copy
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import yaml
 
@@ -53,7 +53,7 @@ class WilmaConfig:
         }
     }
 
-    def __init__(self, config_path: Optional[str] = None):
+    def __init__(self, config_path: str | None = None):
         """
         Initialize Wilma configuration.
 
@@ -63,7 +63,7 @@ class WilmaConfig:
         self.config = copy.deepcopy(self.DEFAULT_CONFIG)
         self._load_config(config_path)
 
-    def _load_config(self, config_path: Optional[str] = None) -> None:
+    def _load_config(self, config_path: str | None = None) -> None:
         """
         Load configuration from file, with fallbacks.
 
@@ -273,7 +273,7 @@ class WilmaConfig:
         print(f"  Enabled Checks: {', '.join(self.enabled_checks)}")
         print()
 
-    def save_default_config(self, output_path: Optional[str] = None) -> str:
+    def save_default_config(self, output_path: str | None = None) -> str:
         """
         Save default configuration to a file.
 

--- a/src/wilma/utils.py
+++ b/src/wilma/utils.py
@@ -11,7 +11,7 @@ the Free Software Foundation, either version 3 of the License, or
 
 import re
 from collections.abc import Iterator
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List
 
 from botocore.exceptions import ClientError
 
@@ -66,7 +66,7 @@ SUSPICIOUS_UNICODE_PATTERNS = [
 # ARN PARSING UTILITIES
 # ============================================================================
 
-def parse_arn(arn: str) -> Optional[Dict[str, str]]:
+def parse_arn(arn: str) -> Dict[str, str] | None:
     """
     Parse an AWS ARN into its components.
 
@@ -134,7 +134,7 @@ def parse_arn(arn: str) -> Optional[Dict[str, str]]:
     return result
 
 
-def extract_resource_from_arn(arn: str, default: Optional[str] = None) -> Optional[str]:
+def extract_resource_from_arn(arn: str, default: str | None = None) -> str | None:
     """
     Extract the resource identifier from an ARN.
 
@@ -460,7 +460,7 @@ def normalize_boto3_tags(tags: List[Dict[str, str]]) -> Dict[str, str]:
 # PII DETECTION UTILITIES
 # ============================================================================
 
-def scan_text_for_pii(text: str, patterns: Optional[Dict[str, str]] = None) -> List[str]:
+def scan_text_for_pii(text: str, patterns: Dict[str, str] | None = None) -> List[str]:
     """
     Scan text for PII patterns.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,18 +215,17 @@ def checker_with_moto(mock_checker):
 @pytest.fixture
 def wilma_config():
     """Create a default Wilma configuration for testing."""
-    return WilmaConfig(
-        region='us-east-1',
-        checks_enabled=[
-            'iam',
-            'genai',
-            'network',
-            'logging',
-            'tagging',
-            'knowledge_bases'
-        ],
-        min_risk_level='LOW'
-    )
+    config = WilmaConfig()
+    config.config['checks']['enabled'] = [
+        'iam',
+        'genai',
+        'network',
+        'logging',
+        'tagging',
+        'knowledge_bases',
+    ]
+    config.config['output']['min_risk_level'] = 'LOW'
+    return config
 
 
 # ============================================================================


### PR DESCRIPTION
Python 3.9 reached end-of-life in October 2025 and the dependency ecosystem (boto3, pytest, moto, build, types-PyYAML) has dropped it, which forced us to reject six Dependabot PRs (#108, #109, #113, #115, #117, #118). This PR drops 3.9 and applies all of those deferred updates.

## Changes

**Python support**
- `requires-python >=3.10`, removed the 3.9 trove classifier
- Removed 3.9 from the test and publish CI matrices
- ruff `target-version = py310`, mypy `python_version = 3.10`
- Updated README badge, CLAUDE.md, CONTRIBUTING.md

**Dependency floors (re-applies closed Dependabot PRs)**
- boto3/botocore >=1.43.51 (#113, #115)
- pytest >=9.1.1 (#109)
- moto >=5.2.2 (#117)
- types-PyYAML >=6.0.12.20260518 (#118)
- build >=1.5.0 (#108)

**Code**
- Applied ruff UP007/UP045 autofixes (PEP 604 `X | None` unions) required by the py310 target

**Release**
- Version bumped to 0.2.2 in pyproject.toml and `wilma/__init__.py`; merging to main auto-publishes to PyPI
- CHANGELOG entry added

## Verification
- 161 tests passed, 2 skipped locally with pytest 9.1.1 and moto 5.2.2
- ruff 0.15.22 clean, bandit clean
- `wilma --version` reports 0.2.2, library API imports fine