### PR TITLE
fix: skip AWS-owned model tag checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+        pip install -e ".[dev,demo]"
 
     - name: Run ruff linter
       run: |

--- a/README.md
+++ b/README.md
@@ -205,6 +205,19 @@ mypy src/wilma --show-error-codes --pretty
 The project uses mocked AWS clients in tests. No real AWS credentials are required for the test suite.
 Mypy is currently informational while type hints are tightened; CI does not block on it.
 
+## Optional live demo fixture
+
+`scripts/demo_setup.py` creates deliberately insecure Bedrock-adjacent resources so you can validate that Wilma finds them. It is **not** part of the mocked test suite. Use only a dedicated, non-production AWS account and clean it up immediately after testing.
+
+```bash
+pip install -e ".[dev,demo]"
+python scripts/demo_setup.py --setup --profile <test-profile> --region us-east-1
+python scripts/demo_setup.py --test --profile <test-profile> --region us-east-1
+python scripts/demo_setup.py --cleanup --profile <test-profile> --region us-east-1
+```
+
+The demo provisions real AWS resources, including OpenSearch Serverless, and can incur charges. Do not run it against production or with credentials that can reach production resources.
+
 ## Release Notes
 
 `0.2.0` is the reboot foundation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ dev = [
     "twine>=6.2.0",
     "tomli>=2.0.0; python_version<'3.11'",  # For reading pyproject.toml in publish workflow
 ]
+demo = [
+    "opensearch-py>=3.1.0,<4.0.0",
+    "requests-aws4auth>=1.3.1,<2.0.0",
+]
 
 # Ruff configuration - Fast Python linter
 [tool.ruff]

--- a/scripts/demo_setup.py
+++ b/scripts/demo_setup.py
@@ -19,7 +19,7 @@ Usage:
     python scripts/demo_setup.py --cleanup    # Delete all resources
     python scripts/demo_setup.py --all        # Full cycle (setup → test → cleanup)
 
-Cost: Minimal (< $0.10, usually free tier eligible)
+Cost: OpenSearch Serverless can incur charges. Use a dedicated test account and clean up promptly.
 WARNING: Real AWS resources are created - remember to cleanup!
 """
 
@@ -72,6 +72,7 @@ class WilmaDemo:
         self.bedrock_agent = self.session.client('bedrock-agent')
         self.aoss = self.session.client('opensearchserverless')
         self.region = region
+        self.profile = profile
         self.account_id = self.session.client('sts').get_caller_identity()['Account']
 
         print(f"[INFO] Initialized demo for account {self.account_id} in region {self.region}")
@@ -83,7 +84,7 @@ class WilmaDemo:
         print("=" * 70)
         print("\n[WARNING] This will create real AWS resources with security issues.")
         print("          These are for demonstration purposes only.")
-        print(f"          Estimated cost: $0.00 - $0.10 (usually free tier)\n")
+        print("          Cost: variable; OpenSearch Serverless can incur charges.\n")
 
         try:
             # Step 1: Create S3 bucket (intentionally insecure)
@@ -161,12 +162,16 @@ class WilmaDemo:
         print("=" * 70)
 
         try:
-            print("\n[INFO] Running: wilma --region " + self.region)
+            command = ['wilma', '--region', self.region]
+            if self.profile:
+                command.extend(['--profile', self.profile])
+
+            print("\n[INFO] Running: " + " ".join(command))
             print("[INFO] This will scan all Bedrock resources including the demo KB\n")
 
-            # Run Wilma
-            result = subprocess.run(
-                ['wilma', '--region', self.region],
+            # The executable is fixed and all values remain individual argv elements.
+            result = subprocess.run(  # nosec B603
+                command,
                 capture_output=True,
                 text=True
             )
@@ -181,7 +186,10 @@ class WilmaDemo:
             print("\nWilma should have detected the intentional security issues.")
             print("Next step: Run 'python scripts/demo_setup.py --cleanup' to remove demo resources")
 
-            return result.returncode == 0
+            # Wilma returns 1/2 for high/critical findings, which are the
+            # expected result for this deliberately insecure fixture. Only a
+            # runtime error (3) means the demo scan itself failed.
+            return result.returncode in (0, 1, 2)
 
         except FileNotFoundError:
             print("\n[ERROR] 'wilma' command not found.")
@@ -849,10 +857,15 @@ def main():
     success = True
 
     if args.all:
-        success = demo.setup() and success
-        if success:
-            time.sleep(5)  # Wait for resources to be fully created
-            success = demo.test() and success
+        setup_success = demo.setup()
+        success = setup_success and success
+        try:
+            if setup_success:
+                time.sleep(5)  # Wait for resources to be fully created
+                success = demo.test() and success
+        finally:
+            # Setup can partially create resources before reporting failure;
+            # test errors must not strand a costly, insecure fixture either.
             time.sleep(2)
             success = demo.cleanup() and success
     else:

--- a/src/wilma/checks/tagging.py
+++ b/src/wilma/checks/tagging.py
@@ -74,23 +74,9 @@ class TaggingSecurityChecks:
         print("[CHECK] Checking resource organization...")
 
         try:
-            foundation_models = self.checker.bedrock.list_foundation_models()
-            for model in foundation_models.get('modelSummaries', []):
-                model_id = model.get('modelId', 'unknown-model')
-                model_arn = model.get('modelArn')
-                if not model_arn:
-                    continue
-
-                try:
-                    tags_response = self.checker.bedrock.list_tags_for_resource(resourceARN=model_arn)
-                    self._check_required_tags(f"Foundation Model: {model_id}", model_arn, tags_response)
-                except ClientError as e:
-                    error_code = e.response['Error']['Code']
-                    if error_code not in ['AccessDenied', 'ResourceNotFoundException']:
-                        handle_aws_error(e, f"checking tags for model {model_id}", log_access_denied=False)
-                except Exception as e:
-                    print(f"[WARN] Unexpected error checking model {model_id}: {str(e)}")
-
+            # Foundation models are AWS-owned resources. Their ARNs are not taggable
+            # by customer accounts, and calling ListTagsForResource for them returns
+            # ValidationException. Only assess taggable, account-owned resources.
             custom_models = self.checker.bedrock.list_custom_models()
             for model in custom_models.get('modelSummaries', []):
                 model_name = model['modelName']

--- a/tests/test_demo_setup.py
+++ b/tests/test_demo_setup.py
@@ -4,9 +4,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 def test_demo_setup_help_runs_without_aws_calls():
     """The demo entrypoint should import and parse --help without AWS access."""
+    pytest.importorskip("opensearchpy")
+    pytest.importorskip("requests_aws4auth")
     project_root = Path(__file__).resolve().parents[1]
     result = subprocess.run(
         [sys.executable, "scripts/demo_setup.py", "--help"],

--- a/tests/test_demo_setup.py
+++ b/tests/test_demo_setup.py
@@ -1,10 +1,21 @@
 """Smoke tests for the optional live-demo helper."""
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
+
+
+def _load_demo_setup(script_path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("wilma_demo_setup", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_demo_setup_help_runs_without_aws_calls():
@@ -22,3 +33,107 @@ def test_demo_setup_help_runs_without_aws_calls():
 
     assert result.returncode == 0, result.stderr
     assert "Create demo resources" in result.stdout
+
+
+def test_demo_test_forwards_the_selected_profile(monkeypatch):
+    """The scan subprocess must use the same profile as the demo resources."""
+    pytest.importorskip("opensearchpy")
+    pytest.importorskip("requests_aws4auth")
+    demo_setup = _load_demo_setup(Path(__file__).resolve().parents[1] / "scripts" / "demo_setup.py")
+    demo = object.__new__(demo_setup.WilmaDemo)
+    demo.region = "us-east-1"
+    demo.profile = "test-sandbox"
+
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 1, "", "")
+
+    monkeypatch.setattr(demo_setup.subprocess, "run", fake_run)
+
+    assert demo.test()
+    assert calls == [
+        (
+            ["wilma", "--region", "us-east-1", "--profile", "test-sandbox"],
+            {"capture_output": True, "text": True},
+        )
+    ]
+
+
+def test_all_attempts_cleanup_after_a_partial_setup_failure(monkeypatch):
+    """The all-in-one path must clean up even when setup reports failure."""
+    pytest.importorskip("opensearchpy")
+    pytest.importorskip("requests_aws4auth")
+    demo_setup = _load_demo_setup(Path(__file__).resolve().parents[1] / "scripts" / "demo_setup.py")
+    calls: list[str] = []
+
+    class PartialSetupDemo:
+        def __init__(self, region: str, profile: str | None):
+            assert region == "us-east-1"
+            assert profile == "test-sandbox"
+
+        def setup(self) -> bool:
+            calls.append("setup")
+            return False
+
+        def test(self) -> bool:
+            calls.append("test")
+            return True
+
+        def cleanup(self) -> bool:
+            calls.append("cleanup")
+            return True
+
+    monkeypatch.setattr(demo_setup, "WilmaDemo", PartialSetupDemo)
+    monkeypatch.setattr(demo_setup.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        demo_setup.sys,
+        "argv",
+        ["demo_setup.py", "--all", "--confirm", "--profile", "test-sandbox"],
+    )
+
+    with pytest.raises(SystemExit) as exited:
+        demo_setup.main()
+
+    assert exited.value.code == 1
+    assert calls == ["setup", "cleanup"]
+
+
+def test_all_attempts_cleanup_after_a_scan_failure(monkeypatch):
+    """The all-in-one path must clean up when Wilma itself fails."""
+    pytest.importorskip("opensearchpy")
+    pytest.importorskip("requests_aws4auth")
+    demo_setup = _load_demo_setup(Path(__file__).resolve().parents[1] / "scripts" / "demo_setup.py")
+    calls: list[str] = []
+
+    class FailedScanDemo:
+        def __init__(self, region: str, profile: str | None):
+            assert region == "us-east-1"
+            assert profile == "test-sandbox"
+
+        def setup(self) -> bool:
+            calls.append("setup")
+            return True
+
+        def test(self) -> bool:
+            calls.append("test")
+            return False
+
+        def cleanup(self) -> bool:
+            calls.append("cleanup")
+            return True
+
+    monkeypatch.setattr(demo_setup, "WilmaDemo", FailedScanDemo)
+    monkeypatch.setattr(demo_setup.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        demo_setup.sys,
+        "argv",
+        ["demo_setup.py", "--all", "--confirm", "--profile", "test-sandbox"],
+    )
+
+    with pytest.raises(SystemExit) as exited:
+        demo_setup.main()
+
+    assert exited.value.code == 1
+    assert calls == ["setup", "test", "cleanup"]

--- a/tests/test_demo_setup.py
+++ b/tests/test_demo_setup.py
@@ -1,0 +1,20 @@
+"""Smoke tests for the optional live-demo helper."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_demo_setup_help_runs_without_aws_calls():
+    """The demo entrypoint should import and parse --help without AWS access."""
+    project_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "scripts/demo_setup.py", "--help"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Create demo resources" in result.stdout

--- a/tests/test_tagging_checks.py
+++ b/tests/test_tagging_checks.py
@@ -13,69 +13,31 @@ from wilma.enums import RiskLevel
 class TestResourceTagging:
     """Test resource tagging compliance checks."""
 
-    def test_untagged_foundation_model(self, mock_checker):
-        """Test detection of foundation models without required tags."""
-        # Configure Bedrock mock to return foundation models
+    def test_foundation_models_are_not_tag_checked(self, mock_checker):
+        """AWS-owned foundation models cannot carry account resource tags."""
         mock_checker.bedrock.list_foundation_models.return_value = {
             'modelSummaries': [
                 {
                     'modelId': 'anthropic.claude-v2',
-                    'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2'
+                    'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2',
                 }
             ]
         }
-        # No tags on this model
-        mock_checker.bedrock.list_tags_for_resource.return_value = {
-            'tags': []
-        }
+        mock_checker.bedrock.list_custom_models.return_value = {'modelSummaries': []}
 
-        # Run check
-        tagging_checks = TaggingSecurityChecks(mock_checker)
-        tagging_checks.check_resource_tagging()
+        TaggingSecurityChecks(mock_checker).check_resource_tagging()
 
-        # Verify LOW finding for missing tags
-        low_findings = [f for f in mock_checker.findings if f.get('risk_level') == RiskLevel.LOW]
-        assert len(low_findings) > 0
+        mock_checker.bedrock.list_foundation_models.assert_not_called()
+        mock_checker.bedrock.list_tags_for_resource.assert_not_called()
+        assert mock_checker.findings == []
 
-    def test_properly_tagged_model(self, mock_checker):
-        """Test that properly tagged models pass validation."""
-        # Configure Bedrock mock
-        mock_checker.bedrock.list_foundation_models.return_value = {
+    def test_partially_tagged_custom_model(self, mock_checker):
+        """Test detection when a custom model is missing required tags."""
+        mock_checker.bedrock.list_custom_models.return_value = {
             'modelSummaries': [
                 {
-                    'modelId': 'anthropic.claude-v2',
-                    'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2'
-                }
-            ]
-        }
-        # Model has all required tags
-        mock_checker.bedrock.list_tags_for_resource.return_value = {
-            'tags': [
-                {'key': 'Environment', 'value': 'production'},
-                {'key': 'Owner', 'value': 'ml-team'},
-                {'key': 'Project', 'value': 'chatbot'},
-                {'key': 'DataClassification', 'value': 'confidential'}
-            ]
-        }
-
-        # Run check
-        tagging_checks = TaggingSecurityChecks(mock_checker)
-        tagging_checks.check_resource_tagging()
-
-        # Verify no LOW findings (all required tags present)
-        low_findings = [f for f in mock_checker.findings
-                       if f.get('risk_level') == RiskLevel.LOW
-                       and 'missing tags' in f.get('title', '').lower()]
-        assert len(low_findings) == 0
-
-    def test_partially_tagged_model(self, mock_checker):
-        """Test detection when some but not all required tags are present."""
-        # Configure Bedrock mock
-        mock_checker.bedrock.list_foundation_models.return_value = {
-            'modelSummaries': [
-                {
-                    'modelId': 'anthropic.claude-v2',
-                    'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2'
+                    'modelName': 'custom-model-1',
+                    'modelArn': 'arn:aws:bedrock:us-east-1:123456789012:custom-model/custom-model-1',
                 }
             ]
         }


### PR DESCRIPTION
## Summary
- Stop tag queries for AWS-owned Bedrock foundation models. Customer accounts cannot tag these ARNs, and querying them produced false `ValidationException` errors.
- Keep tag assessment for account-owned custom models and Knowledge Bases, with a regression test proving foundation models are skipped.
- Add an optional `demo` dependency extra, demo `--help` smoke coverage, and CI installation of the extra.
- Make demo usage safe and account-consistent: forward `--profile` to Wilma, treat expected HIGH/CRITICAL findings as a successful demo scan, and always attempt cleanup in `--all`, even after setup or scan failure.
- Correct the demo’s misleading cost language. OpenSearch Serverless can incur charges.

## Validation
- `pytest --cov=wilma --cov-fail-under=50 -v -m 'not slow'` → `164 passed, 2 skipped`, 56.03% coverage.
- `ruff check src/ tests/` → passed.
- `bandit -r src/ -s B101,B106,B107,B112,B601` → no issues.
- Built `wilma_sec-0.2.2-py3-none-any.whl`.
- A `.[dev]`-only environment skips the optional demo smoke tests cleanly; `.[dev,demo]` runs all four demo tests.
- `gitleaks` scans of both commits and the complete PR diff → no leaks.
- Live, read-only scan of the `zero` test profile in `us-east-1` → same 5 findings / score 46, with `tagging_validation_exceptions=0` and no scanner error lines.

`mypy` remains informational in CI and has existing project-wide typing debt; this change does not alter its enforcement.

## Safety
No AWS resources were created, modified, or deleted. The live demo fixture was not provisioned.